### PR TITLE
[bug] 크로마틱 배포 실패 - package.json의 pnpm 버전과 chromatic.yml 파일에서 pnpm 버전이 다른 이슈 해결

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 8.15.6
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 배포 실패 해결 #134 
- package.json 
  ```
  {
    "packageManager": "pnpm@8.15.6",
  }
  ```
- chromatic.yml
```
- name: Setup pnpm
        uses: pnpm/action-setup@v4
        with:
          version: latest // 8.15.6 으로 수정
```

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
