### PR TITLE
fix: release 액션에서 기존 태그 중복 오류 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -89,8 +89,14 @@ jobs:
       - name: Create and push tag
         if: steps.check-release.outputs.need_release == 'true'
         run: |
-          git tag ${{ steps.release-notes.outputs.NEW_VERSION }}
-          git push origin ${{ steps.release-notes.outputs.NEW_VERSION }}
+          # Check if tag already exists
+          if git rev-parse ${{ steps.release-notes.outputs.NEW_VERSION }} >/dev/null 2>&1; then
+            echo "Tag ${{ steps.release-notes.outputs.NEW_VERSION }} already exists, skipping tag creation"
+          else
+            git tag ${{ steps.release-notes.outputs.NEW_VERSION }}
+            git push origin ${{ steps.release-notes.outputs.NEW_VERSION }}
+            echo "Created and pushed tag ${{ steps.release-notes.outputs.NEW_VERSION }}"
+          fi
           git push origin main
 
       - name: Create GitHub Release
@@ -102,7 +108,8 @@ jobs:
           body: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
           draft: false
           prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Upload release notes as artifact
         if: steps.check-release.outputs.need_release == 'true'


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #137

## 📋 작업 내용

GitHub Actions의 release 워크플로우에서 기존 태그 중복으로 인한 오류를 수정했습니다.

### 주요 수정 사항:
1. **Release 액션 태그 중복 오류 수정**
   - 기존 태그 존재 여부를 확인하는 로직 추가
   - 태그가 이미 존재하는 경우 생성을 건너뛰도록 수정
   - `allowUpdates: true` 옵션으로 릴리즈 업데이트 허용

2. **토큰 설정 개선**
   - `GITHUB_TOKEN` 대신 `RELEASE_TOKEN` 사용으로 권한 문제 해결

## 🔧 변경 사항

- [x] 🧹 GitHub Actions workflow 파일 수정
  - `.github/workflows/release.yml`

### 구체적인 변경 내용:

**release.yml:**
- 태그 생성 전 기존 태그 존재 여부 확인 로직 추가
- `allowUpdates: true` 옵션 추가
- `RELEASE_TOKEN` 사용으로 변경

## 📄 기타
