### PR TITLE
fix: chromatic.yml 파일에서 turbo 명령어의 ui 호출 오탈자 수정 #141

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -75,7 +75,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build UI package and web app
-        run: npx turbo build --filter=ui --filter=web
+        run: npx turbo build --filter=@repo/ui --filter=web
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

ISSUE #141 
#140 PR에서 turbo 명령어 실행시 ui 패키지 호출 명 오탈자를 확인 


## 🔧 변경 사항

- [x] 📃 chromtic.yml 파일 수정

<img width="478" height="64" alt="image" src="https://github.com/user-attachments/assets/3017ab08-dc49-49b2-b8e0-4d2bbe0eccce" />

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

**⏺ Turborepo --filter 규칙**
  - 기본 원칙: package.json의 name 필드와 정확히 일치해야 함
  - apps/web 의 경우 : `"name": "web"`
  - apps/docs 의 경우 : "name": "@repo/ui"

**⏺ Scoped Package vs Regular Package 필터링 규칙 상세 설명:**

NPM Scoped Package 정의

  Scoped Package는 @scope/name 형태의 패키지입니다:
  - @ 기호로 시작하는 조직/사용자 네임스페이스
  - 예: @repo/ui, @typescript-eslint/parser, @tanstack/react-query

  Regular Package는 일반적인 패키지 이름:
  - 단순한 이름 형태
  - 예: web, react, lodash

공식 문서 출처:
  - https://turbo.build/repo/docs/reference/run
  - https://docs.npmjs.com/cli/v10/using-npm/scope


**⏺ Monorepo 패키지 네이밍 컨벤션 분석:**

- 현재 프로젝트의 네이밍 패턴
    packages/ui/         → @repo/ui      (scoped)
    apps/docs/          → @apps/docs     (scoped)
    apps/web/           → web            (unscoped)

- 일반적인 Monorepo 네이밍 컨벤션

1. 표준 패턴 (권장)
    packages/           → @repo/* 또는 @company/*
    apps/              → 일반 이름 (web, docs, mobile)

2. 이 프로젝트의 혼재 이유
    정상적인 패턴:
    - @repo/ui ✅ - 패키지는 scoped로 네임스페이스 관리
    - web ✅ - 앱은 단순 이름으로 배포 가능

    비표준적인 패턴:
      - @apps/docs ❌ - 앱에 스코프를 붙이는 것은 일반적이지 않음 -> 수정이 필요함

3. 표준 베스트 프랙티스

    권장 구조
      packages/ui/        → @repo/ui
      packages/utils/     → @repo/utils
      packages/config/    → @repo/config
    
      apps/web/          → web
      apps/docs/         → docs
      apps/mobile/       → mobile

4. 이유와 목적
      Scoped packages (@repo/*):
      - 내부 패키지의 네임스페이스 관리
      - NPM 충돌 방지