### PR TITLE
feat: 마이페이지 UI 및 로그아웃 기능 구현 (#151)

### DIFF
--- a/apps/web/app/(pages)/mypage/layout.tsx
+++ b/apps/web/app/(pages)/mypage/layout.tsx
@@ -1,0 +1,23 @@
+import { TopNavigation, BottomNavigation, PageContainer } from '@/components/layout';
+
+interface MypageLayoutProps {
+  children: React.ReactNode;
+}
+
+const MypageLayout = ({ children }: MypageLayoutProps) => {
+  return (
+    <div className="h-screen flex flex-col">
+      <TopNavigation title="마이페이지" showBackButton={false} />
+      <PageContainer
+        className="flex-1 py-lg bg-bg-base"
+        hasTopNavigation={true}
+        hasBottomNavigation={true}
+      >
+        {children}
+      </PageContainer>
+      <BottomNavigation />
+    </div>
+  );
+};
+
+export default MypageLayout;

--- a/apps/web/app/(pages)/mypage/page.tsx
+++ b/apps/web/app/(pages)/mypage/page.tsx
@@ -1,0 +1,48 @@
+import { notFound } from 'next/navigation';
+
+import { prisma } from '@/lib/prisma/client';
+
+import {
+  ActivityStats,
+  MypageHeader,
+  SettingsMenu,
+  TradingMenu,
+  LogoutButton,
+} from '@/components/mypage';
+
+import { getAuthenticatedUser } from '@/utils/auth';
+
+const ProfilePage = async () => {
+  const authResult = await getAuthenticatedUser();
+
+  // 사용자 정보 조회
+  const user = await prisma.users.findUnique({
+    where: { user_id: authResult.userId },
+    select: {
+      nickname: true,
+    },
+  });
+
+  // 사용자 정보가 없으면 404 페이지로 이동
+  if (!user) {
+    notFound();
+  }
+
+  return (
+    <div className="flex flex-col gap-md">
+      <MypageHeader userNickname={user.nickname} />
+
+      <ActivityStats />
+
+      <TradingMenu />
+
+      <SettingsMenu />
+
+      <div className="mt-md text-center">
+        <LogoutButton />
+      </div>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/apps/web/components/mypage/ActivityCard.tsx
+++ b/apps/web/components/mypage/ActivityCard.tsx
@@ -1,0 +1,37 @@
+import { Icon } from '@repo/ui/components';
+import type { IconName } from '@repo/ui/components';
+
+interface StatItem {
+  value: string | number;
+  label: string;
+}
+
+interface ActivityCardProps {
+  icon: string;
+  title: string;
+  iconBgColor: string;
+  stats: StatItem[];
+}
+
+const ActivityCard = ({ icon, title, iconBgColor, stats }: ActivityCardProps) => {
+  return (
+    <div className="flex flex-col gap-sm p-sm">
+      <div className="flex items-center justify-center gap-sm">
+        <div className={`w-7 h-7 ${iconBgColor} rounded-md flex items-center justify-center`}>
+          <Icon name={icon as IconName} size="sm" color="inverse" />
+        </div>
+        <h3 className="font-style-medium">{title}</h3>
+      </div>
+      <div className="flex justify-around">
+        {stats.map((stat, index) => (
+          <div key={index} className="text-center">
+            <p className="font-style-headline-h3 mb-xs">{stat.value}</p>
+            <p className="font-style-small text-text-info">{stat.label}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ActivityCard;

--- a/apps/web/components/mypage/ActivityCard.tsx
+++ b/apps/web/components/mypage/ActivityCard.tsx
@@ -7,7 +7,7 @@ interface StatItem {
 }
 
 interface ActivityCardProps {
-  icon: string;
+  icon: IconName;
   title: string;
   iconBgColor: string;
   stats: StatItem[];
@@ -18,7 +18,7 @@ const ActivityCard = ({ icon, title, iconBgColor, stats }: ActivityCardProps) =>
     <div className="flex flex-col gap-sm p-sm">
       <div className="flex items-center justify-center gap-sm">
         <div className={`w-7 h-7 ${iconBgColor} rounded-md flex items-center justify-center`}>
-          <Icon name={icon as IconName} size="sm" color="inverse" />
+          <Icon name={icon} size="sm" color="inverse" />
         </div>
         <h3 className="font-style-medium">{title}</h3>
       </div>

--- a/apps/web/components/mypage/ActivityStats.tsx
+++ b/apps/web/components/mypage/ActivityStats.tsx
@@ -1,0 +1,36 @@
+import ActivityCard from './ActivityCard';
+import MypageSectionCard from './MypageSectionCard';
+
+const ActivityStats = () => {
+  // 추후 데이터 연동
+  const salesStats = [
+    { value: 8, label: '판매중' },
+    { value: 12, label: '판매완료' },
+  ];
+
+  const purchaseStats = [
+    { value: 5, label: '구매완료' },
+    { value: 3, label: '관심상품' },
+  ];
+
+  return (
+    <MypageSectionCard title="활동 통계">
+      <div className="grid grid-cols-2 gap-md">
+        <ActivityCard
+          icon="Export"
+          title="판매 활동"
+          iconBgColor="bg-bg-primary/80"
+          stats={salesStats}
+        />
+        <ActivityCard
+          icon="ShoppingBag"
+          title="구매 활동"
+          iconBgColor="bg-bg-success/80"
+          stats={purchaseStats}
+        />
+      </div>
+    </MypageSectionCard>
+  );
+};
+
+export default ActivityStats;

--- a/apps/web/components/mypage/LogoutButton.tsx
+++ b/apps/web/components/mypage/LogoutButton.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { supabaseClient } from '@/lib/supabase/client';
+
+const LogoutButton = () => {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    // 추후 바텀시트 컴포넌트로 대체
+    if (confirm('로그아웃 하시겠습니까?')) {
+      try {
+        await supabaseClient.auth.signOut();
+        router.push('/login');
+      } catch (error) {
+        console.error('로그아웃 중 오류가 발생했습니다:', error);
+        alert('로그아웃 중 오류가 발생했습니다. 다시 시도해 주세요.');
+      }
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className="font-style-small text-text-danger underline"
+      onClick={handleLogout}
+    >
+      로그아웃
+    </button>
+  );
+};
+
+export default LogoutButton;

--- a/apps/web/components/mypage/MypageHeader.tsx
+++ b/apps/web/components/mypage/MypageHeader.tsx
@@ -1,0 +1,30 @@
+import { Avatar, Icon } from '@repo/ui/components';
+import Link from 'next/link';
+
+interface MypageHeaderProps {
+  userNickname: string;
+}
+
+const MypageHeader = ({ userNickname }: MypageHeaderProps) => {
+  return (
+    <Link href="/profile" className="block">
+      <div className="bg-gradient-to-br from-orange-200 via-orange-400 to-bg-primary px-md py-md rounded-lg shadow-sm">
+        <div className="flex items-center gap-md">
+          <Avatar
+            className="bg-white border-white/30"
+            src="/images/ddip_logo.png"
+            alt="프로필 이미지"
+            size="xl"
+            name={userNickname}
+          />
+          <h1 className="block py-sm font-style-headline-h4 flex-1 truncate text-white drop-shadow-sm">
+            {userNickname}
+          </h1>
+          <Icon name="ArrowRight" size="md" color="inverse" />
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default MypageHeader;

--- a/apps/web/components/mypage/MypageMenuItem.tsx
+++ b/apps/web/components/mypage/MypageMenuItem.tsx
@@ -1,0 +1,28 @@
+import { Icon, type IconName } from '@repo/ui/components';
+import Link from 'next/link';
+
+export interface MypageMenuItemProps {
+  icon: string;
+  title: string;
+  href: string;
+}
+
+const MypageMenuItem = ({ icon, title, href }: MypageMenuItemProps) => {
+  return (
+    <Link href={href} className="flex items-center justify-between py-sm">
+      <div className="flex items-center gap-sm">
+        <div className="w-8 h-8 flex items-center justify-center">
+          <Icon name={icon as IconName} size="sm" color="default" />
+        </div>
+        <div>
+          <h3 className="font-style-medium">{title}</h3>
+        </div>
+      </div>
+      <div className="flex items-center">
+        <Icon name="ArrowRight" size="sm" color="default" />
+      </div>
+    </Link>
+  );
+};
+
+export default MypageMenuItem;

--- a/apps/web/components/mypage/MypageMenuItem.tsx
+++ b/apps/web/components/mypage/MypageMenuItem.tsx
@@ -2,7 +2,7 @@ import { Icon, type IconName } from '@repo/ui/components';
 import Link from 'next/link';
 
 export interface MypageMenuItemProps {
-  icon: string;
+  icon: IconName;
   title: string;
   href: string;
 }
@@ -12,7 +12,7 @@ const MypageMenuItem = ({ icon, title, href }: MypageMenuItemProps) => {
     <Link href={href} className="flex items-center justify-between py-sm">
       <div className="flex items-center gap-sm">
         <div className="w-8 h-8 flex items-center justify-center">
-          <Icon name={icon as IconName} size="sm" color="default" />
+          <Icon name={icon} size="sm" color="default" />
         </div>
         <div>
           <h3 className="font-style-medium">{title}</h3>

--- a/apps/web/components/mypage/MypageSectionCard.tsx
+++ b/apps/web/components/mypage/MypageSectionCard.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+
+interface MypageSectionCardProps {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}
+
+const MypageSectionCard = ({ title, children, className = '' }: MypageSectionCardProps) => {
+  return (
+    <div className={`bg-bg-light rounded-lg p-md shadow-sm ${className}`}>
+      <h2 className="font-style-small text-text-info mb-sm">{title}</h2>
+      {children}
+    </div>
+  );
+};
+
+export default MypageSectionCard;

--- a/apps/web/components/mypage/SettingsMenu.tsx
+++ b/apps/web/components/mypage/SettingsMenu.tsx
@@ -1,0 +1,32 @@
+import MypageMenuItem, { type MypageMenuItemProps } from './MypageMenuItem';
+import MypageSectionCard from './MypageSectionCard';
+
+const SettingsMenu = () => {
+  const settingsMenuItems: MypageMenuItemProps[] = [
+    {
+      icon: 'Location',
+      title: '위치 설정',
+      href: '/location',
+    },
+    {
+      icon: 'Bell',
+      title: '알림 설정',
+      href: '/mypage/notifications',
+    },
+    {
+      icon: 'User',
+      title: '계정 설정',
+      href: '/mypage/settings',
+    },
+  ];
+
+  return (
+    <MypageSectionCard title="설정">
+      {settingsMenuItems.map((item, index) => (
+        <MypageMenuItem key={index} {...item} />
+      ))}
+    </MypageSectionCard>
+  );
+};
+
+export default SettingsMenu;

--- a/apps/web/components/mypage/TradingMenu.tsx
+++ b/apps/web/components/mypage/TradingMenu.tsx
@@ -1,0 +1,32 @@
+import ProfileMenuItem, { type ProfileMenuItemProps } from './MypageMenuItem';
+import MypageSectionCard from './MypageSectionCard';
+
+const TradingMenu = () => {
+  const tradingMenuItems: ProfileMenuItemProps[] = [
+    {
+      icon: 'Export',
+      title: '판매내역',
+      href: '/mypage/sales',
+    },
+    {
+      icon: 'ShoppingBag',
+      title: '구매내역',
+      href: '/mypage/purchases',
+    },
+    {
+      icon: 'Heart',
+      title: '관심목록',
+      href: '/mypage/favorites',
+    },
+  ];
+
+  return (
+    <MypageSectionCard title="거래 관리">
+      {tradingMenuItems.map((item, index) => (
+        <ProfileMenuItem key={index} {...item} />
+      ))}
+    </MypageSectionCard>
+  );
+};
+
+export default TradingMenu;

--- a/apps/web/components/mypage/index.ts
+++ b/apps/web/components/mypage/index.ts
@@ -1,0 +1,6 @@
+export { default as ActivityStats } from './ActivityStats';
+export { default as MypageHeader } from './MypageHeader';
+export { default as MypageMenuItem } from './MypageMenuItem';
+export { default as SettingsMenu } from './SettingsMenu';
+export { default as TradingMenu } from './TradingMenu';
+export { default as LogoutButton } from './LogoutButton';

--- a/apps/web/constants/navigation.ts
+++ b/apps/web/constants/navigation.ts
@@ -25,4 +25,10 @@ export const BOTTOM_NAVIGATION_ITEMS: NavigationItem[] = [
     icon: 'Chat',
     activeIcon: 'ChatFill',
   },
+  {
+    href: '/mypage',
+    label: '마이페이지',
+    icon: 'User',
+    activeIcon: 'UserFill',
+  },
 ];

--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -54,7 +54,7 @@ export async function updateSession(request: NextRequest) {
   }
 
   // 로그인된 사용자의 위치 정보 확인
-  const protectedPaths = ['/', '/products', '/chat'];
+  const protectedPaths = ['/', '/products', '/chat', '/mypage'];
   const isProtectedPage = protectedPaths.some(
     (path) => pathname === path || pathname.startsWith(`${path}/`)
   );

--- a/packages/ui/src/design-system/base-components/Icons/assets/Icons.ts
+++ b/packages/ui/src/design-system/base-components/Icons/assets/Icons.ts
@@ -2,8 +2,8 @@ import { FaAngleDown, FaAngleLeft, FaAngleRight, FaAngleUp } from 'react-icons/f
 import { GoBellFill, GoBell, GoHeartFill, GoHeart, GoHome, GoHomeFill } from 'react-icons/go';
 import { BsClockFill, BsClock, BsChat, BsChatFill } from 'react-icons/bs';
 import { RxHamburgerMenu } from 'react-icons/rx';
-import { MdRefresh, MdOutlinePhotoCamera } from 'react-icons/md';
-import { PiMagnifyingGlassBold, PiExport, PiExportFill } from 'react-icons/pi';
+import { MdRefresh, MdOutlinePhotoCamera, MdOutlineLocationOn } from 'react-icons/md';
+import { PiMagnifyingGlassBold, PiExport, PiExportFill, PiUser, PiUserFill } from 'react-icons/pi';
 import { HiOutlineShoppingBag, HiShoppingBag } from 'react-icons/hi';
 
 export const ICONS = {
@@ -37,6 +37,11 @@ export const ICONS = {
 
   Export: PiExport,
   ExportFill: PiExportFill,
+
+  User: PiUser,
+  UserFill: PiUserFill,
+
+  Location: MdOutlineLocationOn,
 };
 
 export type IconName = keyof typeof ICONS;

--- a/packages/ui/src/design-system/base-components/Icons/index.ts
+++ b/packages/ui/src/design-system/base-components/Icons/index.ts
@@ -1,1 +1,2 @@
 export { Icon } from './Icon';
+export type { IconName } from './assets/Icons';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #151

## 📋 작업 내용

마이페이지 UI 구성요소와 로그아웃 기능을 구현했습니다.

### 주요 구현 사항
- 마이페이지 레이아웃 및 페이지 구조 설계
- 사용자 프로필 헤더 컴포넌트 (닉네임, 프로필 이미지 표시)
- 활동 통계 컴포넌트 (판매/구매 현황)
- 거래 관리 메뉴 (판매내역, 구매내역, 관심목록)
- 설정 메뉴 (위치설정, 알림설정, 계정설정)
- Supabase 연동 로그아웃 기능
- 마이페이지 관련 아이콘 추가
- 네비게이션에 마이페이지 링크 추가
- 미들웨어 보호 경로 설정

## 🔧 변경 사항

- [x] 🎨 UI 컴포넌트 (마이페이지 관련 컴포넌트 11개)
- [x] 📄 페이지 구조 (레이아웃, 메인 페이지)
- [x] 🔐 인증 기능 (로그아웃 구현)
- [x] 🧭 네비게이션 업데이트
- [x] 🔒 미들웨어 보호 경로 설정
- [x] 📦 아이콘 리소스 추가

### 파일 변경사항 요약
- **새로 추가된 파일**: 마이페이지 레이아웃, 페이지, 컴포넌트 11개
- **수정된 파일**: 네비게이션, 미들웨어, 아이콘 리소스
- **기능 구현**: 사용자 인증 기반 페이지 접근 제어

## 📸 스크린샷 (선택 사항)
<img width="424" height="933" alt="image" src="https://github.com/user-attachments/assets/55c47675-15bf-47b2-b3d1-a20f74380972" />


## 📄 기타

- 모든 링크는 향후 구현 예정 페이지로 연결