### PR TITLE
feat: bottomsheet 및 actionsheet 컴포넌트 추가 (#180)

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -45,8 +45,10 @@ const RootLayout = async ({ children }: { children: React.ReactNode }) => {
         <QueryProvider>
           <HydrationBoundary state={dehydrate(queryClient)}>
             <div className="flex min-h-screen justify-center">
-              <div className="w-full md:max-w-container transform translate-x-0 overflow-x-hidden bg-bg-light">
+              <div className="w-full md:max-w-container transform translate-x-0 overflow-x-hidden bg-bg-light relative">
                 {children}
+                {/* 바텀시트 포털 컨테이너 */}
+                <div id="bottom-sheet-root" className="relative z-50" />
               </div>
             </div>
           </HydrationBoundary>

--- a/packages/ui/src/design-system/base-components/ActionSheet/ActionSheet.stories.tsx
+++ b/packages/ui/src/design-system/base-components/ActionSheet/ActionSheet.stories.tsx
@@ -1,0 +1,220 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+
+import { Button } from '@ui/components';
+
+import ActionSheet from './ActionSheet';
+
+const meta: Meta<typeof ActionSheet> = {
+  title: 'Design System/Base Components/ActionSheet',
+  component: ActionSheet,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: '액션 리스트를 보여주는 바텀시트 컴포넌트입니다.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ActionSheet>;
+
+// 상태를 포함한 래퍼 컴포넌트
+const ActionSheetWithState = (args: any) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="p-4">
+      <Button onClick={() => setIsOpen(true)}>액션시트 열기</Button>
+      <ActionSheet {...args} isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </div>
+  );
+};
+
+// 기본 액션시트
+export const Default: Story = {
+  render: ActionSheetWithState,
+  args: {
+    title: '옵션 선택',
+    items: [
+      {
+        label: '공유하기',
+        onClick: () => console.log('공유하기'),
+      },
+      {
+        label: '수정하기',
+        onClick: () => console.log('수정하기'),
+      },
+      {
+        label: '삭제하기',
+        variant: 'danger' as const,
+        onClick: () => console.log('삭제하기'),
+      },
+    ],
+  },
+};
+
+// 제목 없는 액션시트
+export const WithoutTitle: Story = {
+  render: ActionSheetWithState,
+  args: {
+    items: [
+      {
+        label: '카메라로 촬영',
+        onClick: () => console.log('카메라'),
+      },
+      {
+        label: '갤러리에서 선택',
+        onClick: () => console.log('갤러리'),
+      },
+    ],
+  },
+};
+
+// 아이콘 없는 액션시트
+export const WithoutIcons: Story = {
+  render: ActionSheetWithState,
+  args: {
+    title: '정렬 옵션',
+    items: [
+      {
+        label: '날짜순',
+        onClick: () => console.log('날짜순'),
+      },
+      {
+        label: '이름순',
+        onClick: () => console.log('이름순'),
+      },
+      {
+        label: '크기순',
+        onClick: () => console.log('크기순'),
+      },
+    ],
+  },
+};
+
+// 비활성화된 아이템이 포함된 액션시트
+export const WithDisabledItems: Story = {
+  render: ActionSheetWithState,
+  args: {
+    title: '파일 옵션',
+    items: [
+      {
+        label: '다운로드',
+        onClick: () => console.log('다운로드'),
+      },
+      {
+        label: '공유하기',
+        disabled: true,
+        onClick: () => console.log('공유하기'),
+      },
+      {
+        label: '삭제하기',
+        variant: 'danger' as const,
+        disabled: true,
+        onClick: () => console.log('삭제하기'),
+      },
+    ],
+  },
+};
+
+// 취소 버튼 없는 액션시트
+export const WithoutCancel: Story = {
+  render: ActionSheetWithState,
+  args: {
+    title: '언어 선택',
+    showCancel: false,
+    items: [
+      {
+        label: '한국어',
+        onClick: () => console.log('한국어'),
+      },
+      {
+        label: 'English',
+        onClick: () => console.log('English'),
+      },
+      {
+        label: '日本語',
+        onClick: () => console.log('日本語'),
+      },
+    ],
+  },
+};
+
+// 긴 리스트 액션시트
+export const LongList: Story = {
+  render: ActionSheetWithState,
+  args: {
+    title: '카테고리 선택',
+    items: [
+      { label: '전자제품', onClick: () => console.log('전자제품') },
+      { label: '의류', onClick: () => console.log('의류') },
+      { label: '도서', onClick: () => console.log('도서') },
+      { label: '가전제품', onClick: () => console.log('가전제품') },
+      { label: '스포츠', onClick: () => console.log('스포츠') },
+      { label: '뷰티', onClick: () => console.log('뷰티') },
+      { label: '식품', onClick: () => console.log('식품') },
+      { label: '완구', onClick: () => console.log('완구') },
+      { label: '가구', onClick: () => console.log('가구') },
+      { label: '자동차용품', onClick: () => console.log('자동차용품') },
+    ],
+  },
+};
+
+// 사용자 프로필 옵션 액션시트
+export const UserProfileOptions: Story = {
+  render: ActionSheetWithState,
+  args: {
+    title: '사용자 옵션',
+    items: [
+      {
+        label: '프로필 보기',
+        onClick: () => console.log('프로필 보기'),
+      },
+      {
+        label: '메시지 보내기',
+        onClick: () => console.log('메시지 보내기'),
+      },
+      {
+        label: '차단하기',
+        variant: 'danger' as const,
+        onClick: () => console.log('차단하기'),
+      },
+      {
+        label: '신고하기',
+        variant: 'danger' as const,
+        onClick: () => console.log('신고하기'),
+      },
+    ],
+  },
+};
+
+// 상품 옵션 액션시트
+export const ProductOptions: Story = {
+  render: ActionSheetWithState,
+  args: {
+    title: '상품 옵션',
+    items: [
+      {
+        label: '수정하기',
+        onClick: () => console.log('수정하기'),
+      },
+      {
+        label: '복사하기',
+        onClick: () => console.log('복사하기'),
+      },
+      {
+        label: '공유하기',
+        onClick: () => console.log('공유하기'),
+      },
+      {
+        label: '삭제하기',
+        variant: 'danger' as const,
+        onClick: () => console.log('삭제하기'),
+      },
+    ],
+  },
+};

--- a/packages/ui/src/design-system/base-components/ActionSheet/ActionSheet.tsx
+++ b/packages/ui/src/design-system/base-components/ActionSheet/ActionSheet.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { BottomSheet } from '@ui/components';
+import type { BottomSheetProps } from '@ui/components';
+import { cn } from '@ui/utils/cn';
+
+export interface ActionSheetItem {
+  /** 표시될 라벨 텍스트 */
+  label: string;
+  /** 아이템 스타일 변형 */
+  variant?: 'default' | 'danger';
+  /** 비활성화 상태 */
+  disabled?: boolean;
+  /** 클릭 시 실행될 함수 */
+  onClick: () => void;
+}
+
+export interface ActionSheetProps extends Omit<BottomSheetProps, 'children'> {
+  /** 액션 아이템 목록 */
+  items: ActionSheetItem[];
+  /** 취소 버튼 라벨 */
+  cancelLabel?: string;
+  /** 취소 버튼 표시 여부 */
+  showCancel?: boolean;
+  /** 취소 버튼 클릭 시 실행될 함수 */
+  onCancel?: () => void;
+  /** 아이템 버튼 커스텀 클래스 */
+  itemClassName?: string;
+  /** 취소 버튼 커스텀 클래스 */
+  cancelClassName?: string;
+}
+
+const ActionSheet = ({
+  items,
+  cancelLabel = '취소',
+  showCancel = true,
+  onCancel,
+  itemClassName,
+  cancelClassName,
+  onClose,
+  ...bottomSheetProps
+}: ActionSheetProps) => {
+  // 아이템 클릭 처리
+  const handleItemClick = (item: ActionSheetItem) => {
+    if (!item.disabled) {
+      item.onClick();
+      onClose();
+    }
+  };
+
+  // 취소 버튼 클릭 처리
+  const handleCancelClick = () => {
+    if (onCancel) {
+      onCancel();
+    }
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      {...bottomSheetProps}
+      onClose={onClose}
+      showHandle={false}
+      className={bottomSheetProps.className}
+    >
+      <div className="space-y-xs">
+        {/* 액션 아이템들 */}
+        {items.map((item, index) => (
+          <button
+            key={`${item.label}-${index}`}
+            onClick={() => handleItemClick(item)}
+            disabled={item.disabled}
+            className={cn(
+              'w-full flex items-center justify-center px-container py-md',
+              'font-style-medium text-center rounded-lg transition-colors',
+              // 기본 스타일
+              item.variant === 'danger'
+                ? 'text-text-danger bg-bg-danger/10'
+                : 'text-text-base bg-bg-light',
+              // 비활성화 상태
+              item.disabled && 'text-text-disabled bg-bg-disabled cursor-not-allowed',
+              itemClassName
+            )}
+          >
+            {item.label}
+          </button>
+        ))}
+
+        {/* 취소 버튼 */}
+        {showCancel && (
+          <>
+            <div className="h-2" />
+            <button
+              onClick={handleCancelClick}
+              className={cn(
+                'w-full flex items-center justify-center px-container py-md',
+                'font-style-medium text-text-base text-center rounded-lg',
+                'bg-bg-base',
+                cancelClassName
+              )}
+            >
+              {cancelLabel}
+            </button>
+          </>
+        )}
+      </div>
+    </BottomSheet>
+  );
+};
+
+export default ActionSheet;

--- a/packages/ui/src/design-system/base-components/ActionSheet/ActionSheet.tsx
+++ b/packages/ui/src/design-system/base-components/ActionSheet/ActionSheet.tsx
@@ -38,6 +38,7 @@ const ActionSheet = ({
   itemClassName,
   cancelClassName,
   onClose,
+  portalContainer,
   ...bottomSheetProps
 }: ActionSheetProps) => {
   // 아이템 클릭 처리
@@ -61,6 +62,7 @@ const ActionSheet = ({
       {...bottomSheetProps}
       onClose={onClose}
       showHandle={false}
+      portalContainer={portalContainer}
       className={bottomSheetProps.className}
     >
       <div className="space-y-xs">

--- a/packages/ui/src/design-system/base-components/ActionSheet/index.ts
+++ b/packages/ui/src/design-system/base-components/ActionSheet/index.ts
@@ -1,0 +1,2 @@
+export { default as ActionSheet } from './ActionSheet';
+export type { ActionSheetProps, ActionSheetItem } from './ActionSheet';

--- a/packages/ui/src/design-system/base-components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/ui/src/design-system/base-components/BottomSheet/BottomSheet.stories.tsx
@@ -1,0 +1,204 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+
+import { Button } from '@ui/components';
+
+import BottomSheet from './BottomSheet';
+
+const meta: Meta<typeof BottomSheet> = {
+  title: 'Design System/Base Components/BottomSheet',
+  component: BottomSheet,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: '화면 하단에서 슬라이드업되는 바텀시트 컴포넌트입니다.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof BottomSheet>;
+
+// 상태를 포함한 래퍼 컴포넌트
+const BottomSheetWithState = (args: any) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="p-4">
+      <Button onClick={() => setIsOpen(true)}>바텀시트 열기</Button>
+      <BottomSheet {...args} isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </div>
+  );
+};
+
+// 기본 바텀시트
+export const Default: Story = {
+  render: BottomSheetWithState,
+  args: {
+    title: '바텀시트 제목',
+    children: (
+      <div className="space-y-4">
+        <p>바텀시트 내용입니다.</p>
+        <Button size="md">확인</Button>
+      </div>
+    ),
+  },
+};
+
+// 제목 없는 바텀시트
+export const WithoutTitle: Story = {
+  render: BottomSheetWithState,
+  args: {
+    children: (
+      <div className="space-y-4">
+        <h3 className="font-style-large text-text-base">사용자 정의 제목</h3>
+        <p>제목 없는 바텀시트입니다.</p>
+        <Button size="md">확인</Button>
+      </div>
+    ),
+  },
+};
+
+// 핸들 없는 바텀시트
+export const WithoutHandle: Story = {
+  render: BottomSheetWithState,
+  args: {
+    title: '핸들 없는 바텀시트',
+    showHandle: false,
+    children: (
+      <div className="space-y-4">
+        <p>핸들이 없는 바텀시트입니다.</p>
+        <Button size="md">확인</Button>
+      </div>
+    ),
+  },
+};
+
+// 전체 높이 바텀시트
+export const FullHeight: Story = {
+  render: BottomSheetWithState,
+  args: {
+    title: '전체 높이 바텀시트',
+    height: 'full',
+    children: (
+      <div className="space-y-4">
+        <p>전체 높이를 차지하는 바텀시트입니다.</p>
+        <div className="space-y-2">
+          {Array.from({ length: 20 }, (_, i) => (
+            <div key={i} className="p-3 bg-bg-base rounded-lg">
+              리스트 아이템 {i + 1}
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  },
+};
+
+// 커스텀 높이 바텀시트
+export const CustomHeight: Story = {
+  render: BottomSheetWithState,
+  args: {
+    title: '커스텀 높이 바텀시트',
+    height: 400,
+    children: (
+      <div className="space-y-4">
+        <p>400px 높이의 바텀시트입니다.</p>
+        <div className="space-y-2">
+          {Array.from({ length: 10 }, (_, i) => (
+            <div key={i} className="p-3 bg-bg-base rounded-lg">
+              리스트 아이템 {i + 1}
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  },
+};
+
+// 백드롭 클릭 방지 바텀시트
+export const PreventBackdropClose: Story = {
+  render: BottomSheetWithState,
+  args: {
+    title: '백드롭 클릭 방지',
+    preventBackdropClose: true,
+    children: (
+      <div className="space-y-4">
+        <p>백드롭을 클릭해도 닫히지 않습니다.</p>
+        <p className="text-text-info text-sm">ESC 키나 버튼을 사용해서 닫아주세요.</p>
+        <Button size="md" onClick={() => {}}>
+          닫기
+        </Button>
+      </div>
+    ),
+  },
+};
+
+// 폼이 포함된 바텀시트
+export const WithForm: Story = {
+  render: BottomSheetWithState,
+  args: {
+    title: '폼 입력',
+    children: (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <label className="block text-text-base font-style-medium">이름</label>
+          <input
+            type="text"
+            className="w-full px-3 py-2 border border-border-base rounded-lg"
+            placeholder="이름을 입력하세요"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-text-base font-style-medium">이메일</label>
+          <input
+            type="email"
+            className="w-full px-3 py-2 border border-border-base rounded-lg"
+            placeholder="이메일을 입력하세요"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-text-base font-style-medium">메시지</label>
+          <textarea
+            className="w-full px-3 py-2 border border-border-base rounded-lg h-24"
+            placeholder="메시지를 입력하세요"
+          />
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outlined" size="md" className="flex-1">
+            취소
+          </Button>
+          <Button size="md" className="flex-1">
+            확인
+          </Button>
+        </div>
+      </div>
+    ),
+  },
+};
+
+// 스크롤 가능한 긴 콘텐츠
+export const LongContent: Story = {
+  render: BottomSheetWithState,
+  args: {
+    title: '긴 콘텐츠',
+    children: (
+      <div className="space-y-4">
+        <p>스크롤 가능한 긴 콘텐츠입니다.</p>
+        <div className="space-y-3">
+          {Array.from({ length: 50 }, (_, i) => (
+            <div key={i} className="p-4 bg-bg-base rounded-lg">
+              <h4 className="font-style-medium text-text-base">아이템 {i + 1}</h4>
+              <p className="text-text-info text-sm mt-1">
+                아이템 {i + 1}에 대한 상세 설명입니다. 이 내용은 스크롤을 통해 확인할 수 있습니다.
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  },
+};

--- a/packages/ui/src/design-system/base-components/BottomSheet/BottomSheet.tsx
+++ b/packages/ui/src/design-system/base-components/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { createPortal } from 'react-dom';
+
+import { cn } from '@ui/utils/cn';
+
+import { useBottomSheetState, useBottomSheetInteractions } from './hooks';
+
+export interface BottomSheetProps {
+  /** 바텀시트 열림/닫힘 상태 */
+  isOpen: boolean;
+  /** 바텀시트 닫기 함수 */
+  onClose: () => void;
+  /** 바텀시트 내부 콘텐츠 */
+  children: React.ReactNode;
+  /** 바텀시트 제목 */
+  title?: string;
+  /** 바텀시트 커스텀 클래스 */
+  className?: string;
+  /** 오버레이 커스텀 클래스 */
+  overlayClassName?: string;
+  /** 바텀시트 높이 설정 */
+  height?: 'auto' | 'full' | number;
+  /** 상단 핸들 표시 여부 */
+  showHandle?: boolean;
+  /** 백드롭 클릭으로 닫기 방지 */
+  preventBackdropClose?: boolean;
+  /** 접근성을 위한 aria-label */
+  'aria-label'?: string;
+}
+
+const BottomSheet = ({
+  isOpen,
+  onClose,
+  children,
+  title,
+  className,
+  overlayClassName,
+  height = 'auto',
+  showHandle = true,
+  preventBackdropClose = false,
+  'aria-label': ariaLabel,
+}: BottomSheetProps) => {
+  // 바텀시트 상태 및 기본 동작 관리
+  const { shouldRender, isAnimating, sheetRef } = useBottomSheetState(isOpen, onClose);
+
+  // 터치 제스처 및 백드롭 클릭 처리
+  const { handleTouchStart, handleBackdropClick } = useBottomSheetInteractions(
+    showHandle,
+    preventBackdropClose,
+    onClose
+  );
+
+  // 높이 클래스 계산 함수
+  const getHeightClass = () => {
+    if (height === 'full') return 'h-full';
+    if (height === 'auto') return 'h-auto max-h-[90vh]';
+    if (typeof height === 'number') return `h-[${height}px]`;
+    return 'h-auto max-h-[90vh]';
+  };
+
+  if (!shouldRender) return null;
+
+  const bottomSheetContent = (
+    <div
+      className={cn('fixed inset-0 z-50 flex items-end justify-center', overlayClassName)}
+      role="dialog"
+      aria-modal="true"
+      aria-label={ariaLabel || title || 'Bottom Sheet'}
+    >
+      {/* 백드롭 */}
+      <div
+        className={cn(
+          'absolute inset-0 bg-bg-dark/50 backdrop-blur-sm transition-opacity duration-300',
+          isAnimating ? 'opacity-100' : 'opacity-0'
+        )}
+        onClick={handleBackdropClick}
+      />
+
+      {/* 바텀시트 */}
+      <div
+        ref={sheetRef}
+        className={cn(
+          'relative w-full bg-bg-light rounded-t-xl shadow-lg transform transition-transform duration-300 ease-out flex flex-col',
+          getHeightClass(),
+          isAnimating ? 'translate-y-0' : 'translate-y-full',
+          className
+        )}
+        onTouchStart={handleTouchStart}
+      >
+        {/* 핸들 */}
+        {showHandle && (
+          <div className="flex justify-center pt-sm pb-xs">
+            <div className="w-10 h-1 bg-border-base rounded-full" />
+          </div>
+        )}
+
+        {/* 제목 */}
+        {title && (
+          <div className="px-container py-sm border-b border-border-base">
+            <h2 className="font-style-large text-text-base text-center">{title}</h2>
+          </div>
+        )}
+
+        {/* 콘텐츠 */}
+        <div
+          className={cn(
+            'px-container',
+            title ? 'pt-md' : showHandle ? 'pt-xs' : 'pt-md',
+            'pb-md overflow-y-auto flex-1 min-h-0'
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+
+  // 포털을 통해 렌더링
+  if (typeof document !== 'undefined') {
+    return createPortal(bottomSheetContent, document.body);
+  }
+
+  return null;
+};
+
+export default BottomSheet;

--- a/packages/ui/src/design-system/base-components/BottomSheet/BottomSheet.tsx
+++ b/packages/ui/src/design-system/base-components/BottomSheet/BottomSheet.tsx
@@ -27,6 +27,8 @@ export interface BottomSheetProps {
   preventBackdropClose?: boolean;
   /** 접근성을 위한 aria-label */
   'aria-label'?: string;
+  /** 포털 컨테이너 선택자 (기본값: #bottom-sheet-root) */
+  portalContainer?: string;
 }
 
 const BottomSheet = ({
@@ -40,6 +42,7 @@ const BottomSheet = ({
   showHandle = true,
   preventBackdropClose = false,
   'aria-label': ariaLabel,
+  portalContainer,
 }: BottomSheetProps) => {
   // 바텀시트 상태 및 기본 동작 관리
   const { shouldRender, isAnimating, sheetRef } = useBottomSheetState(isOpen, onClose);
@@ -71,7 +74,7 @@ const BottomSheet = ({
       {/* 백드롭 */}
       <div
         className={cn(
-          'absolute inset-0 bg-bg-dark/50 backdrop-blur-sm transition-opacity duration-300',
+          'absolute inset-0 bg-bg-dark/50 transition-opacity duration-300',
           isAnimating ? 'opacity-100' : 'opacity-0'
         )}
         onClick={handleBackdropClick}
@@ -118,7 +121,10 @@ const BottomSheet = ({
 
   // 포털을 통해 렌더링
   if (typeof document !== 'undefined') {
-    return createPortal(bottomSheetContent, document.body);
+    const defaultContainer = '#bottom-sheet-root';
+    const containerSelector = portalContainer || defaultContainer;
+    const container = document.querySelector(containerSelector) || document.body;
+    return createPortal(bottomSheetContent, container);
   }
 
   return null;

--- a/packages/ui/src/design-system/base-components/BottomSheet/hooks/index.ts
+++ b/packages/ui/src/design-system/base-components/BottomSheet/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useBottomSheetState } from './useBottomSheetState';
+export { useBottomSheetInteractions } from './useBottomSheetGestures';

--- a/packages/ui/src/design-system/base-components/BottomSheet/hooks/useBottomSheetGestures.ts
+++ b/packages/ui/src/design-system/base-components/BottomSheet/hooks/useBottomSheetGestures.ts
@@ -1,0 +1,78 @@
+/**
+ * 바텀시트 상호작용(터치, 백드롭 클릭) 처리를 담당하는 훅
+ */
+export const useBottomSheetInteractions = (
+  showHandle: boolean,
+  preventBackdropClose: boolean,
+  onClose: () => void
+) => {
+  // 터치 제스처 처리
+  const handleTouchStart = (event: React.TouchEvent) => {
+    if (!showHandle) return;
+
+    const touch = event.touches[0];
+    if (!touch) return;
+
+    const startY = touch.clientY;
+    const target = event.target as HTMLElement;
+
+    // 상호작용 요소들에서는 터치 제스처 비활성화
+    if (
+      target.tagName === 'INPUT' ||
+      target.tagName === 'TEXTAREA' ||
+      target.tagName === 'BUTTON' ||
+      target.tagName === 'SELECT' ||
+      target.closest('button') ||
+      target.closest('input') ||
+      target.closest('textarea') ||
+      target.closest('select') ||
+      target.closest('[role="button"]')
+    ) {
+      return;
+    }
+
+    // 스크롤 가능한 영역에서 스크롤이 맨 위에 있지 않으면 터치 제스처 비활성화
+    const scrollableParent = target.closest(
+      '.overflow-y-auto, [style*="overflow-y: auto"], [style*="overflow: auto"]'
+    ) as HTMLElement;
+    if (scrollableParent && scrollableParent.scrollTop > 0) {
+      return;
+    }
+
+    const handleTouchMove = (moveEvent: TouchEvent) => {
+      const currentTouch = moveEvent.touches[0];
+      if (!currentTouch) return;
+
+      const currentY = currentTouch.clientY;
+      const deltaY = currentY - startY;
+
+      if (deltaY > 100) {
+        onClose();
+        document.removeEventListener('touchmove', handleTouchMove);
+      }
+    };
+
+    document.addEventListener('touchmove', handleTouchMove);
+
+    const handleTouchEnd = () => {
+      document.removeEventListener('touchmove', handleTouchMove);
+      document.removeEventListener('touchend', handleTouchEnd);
+    };
+
+    document.addEventListener('touchend', handleTouchEnd);
+  };
+
+  // 백드롭 클릭 처리
+  const handleBackdropClick = (event: React.MouseEvent) => {
+    if (preventBackdropClose) return;
+
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return {
+    handleTouchStart,
+    handleBackdropClick,
+  };
+};

--- a/packages/ui/src/design-system/base-components/BottomSheet/hooks/useBottomSheetState.ts
+++ b/packages/ui/src/design-system/base-components/BottomSheet/hooks/useBottomSheetState.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * 바텀시트의 상태와 기본 동작을 관리하는 메인 훅
+ */
+export const useBottomSheetState = (isOpen: boolean, onClose: () => void) => {
+  // 애니메이션 상태
+  const [shouldRender, setShouldRender] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  // 참조
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // 애니메이션 및 렌더링 상태 관리
+  useEffect(() => {
+    if (isOpen) {
+      setShouldRender(true);
+      const timer = setTimeout(() => {
+        setIsAnimating(true);
+      }, 10);
+
+      return () => clearTimeout(timer);
+    } else {
+      setIsAnimating(false);
+      const timer = setTimeout(() => {
+        setShouldRender(false);
+      }, 300);
+
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  // 포커스 관리
+  useEffect(() => {
+    if (isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+
+      const firstFocusable = sheetRef.current?.querySelector(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      ) as HTMLElement;
+
+      if (firstFocusable) {
+        firstFocusable.focus();
+      }
+    } else {
+      if (previousFocusRef.current) {
+        previousFocusRef.current.focus();
+      }
+    }
+  }, [isOpen]);
+
+  // body 스크롤 방지
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  // ESC 키 처리
+  useEffect(() => {
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscapeKey);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscapeKey);
+    };
+  }, [isOpen, onClose]);
+
+  return {
+    shouldRender,
+    isAnimating,
+    sheetRef,
+  };
+};

--- a/packages/ui/src/design-system/base-components/BottomSheet/index.ts
+++ b/packages/ui/src/design-system/base-components/BottomSheet/index.ts
@@ -1,0 +1,2 @@
+export { default as BottomSheet } from './BottomSheet';
+export type { BottomSheetProps } from './BottomSheet';

--- a/packages/ui/src/design-system/base-components/index.ts
+++ b/packages/ui/src/design-system/base-components/index.ts
@@ -10,3 +10,5 @@ export * from './Button';
 export * from './Thumbnail';
 export * from './IconButton';
 export * from './Tabs';
+export * from './BottomSheet';
+export * from './ActionSheet';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #180

## 📋 작업 내용

UI 디자인 시스템에 BottomSheet와 ActionSheet 컴포넌트를 추가했습니다.

### BottomSheet 컴포넌트
- 터치 제스처 지원으로 스와이프하여 닫기 기능 구현
- 백드롭 클릭으로 닫기 기능 (옵션으로 비활성화 가능)
- 접근성 지원 (포커스 트랩, ESC 키 지원)
- 반응형 높이 조절 및 스크롤 처리
- 애니메이션과 상태 관리를 위한 커스텀 훅 분리

### ActionSheet 컴포넌트
- BottomSheet를 기반으로 한 액션 리스트 컴포넌트
- danger 상태의 배경색과 텍스트 색상 일관성 확보
- 비활성화 상태 및 취소 버튼 옵션 지원

## 🔧 변경 사항

- [x] 새로운 컴포넌트 추가
- [x] 타입 정의 및 인터페이스 구성
- [x] Storybook 스토리 작성
- [x] 디자인 토큰 활용한 스타일링

### 주요 변경 사항:
- **BottomSheet**:새로운 컴포넌트 추가
- **ActionSheet**: 새로운 컴포넌트 추가

## 📸 스크린샷 (선택 사항)
- ActionSheet 
<img width="772" height="459" alt="image" src="https://github.com/user-attachments/assets/1609a5d6-5526-49bf-8e0f-70a0e9d01013" />

- BottomSheet
<img width="774" height="805" alt="image" src="https://github.com/user-attachments/assets/007e3912-3c10-4c0d-97d8-d45eb7703962" />

- backdrop filter 제거 버전
<img width="419" height="929" alt="image" src="https://github.com/user-attachments/assets/a930e933-82d4-4822-9112-f9d1cb1beb2d" />

## 🗒️ 메모

backdrop filter가 없는 버전이 덜 답답해보여서 빼는걸로 수정하겠습니다!