### PR TITLE
[refactor] web app 내 @web 별칭을 점진적으로 사용 가능하도록 절대경로 별칭 추가 설정 #164

### DIFF
--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -33,7 +33,9 @@ const config: StorybookConfig = {
       /* 스토리북 별칭 이슈 해결을 위한 경로 매칭 */
       '@ui/components': join(__dirname, '../../../packages/ui/src/design-system/base-components'),
       '@ui': join(__dirname, '../../../packages/ui/src'),
-      /* @web 의 경우 @web 내부에서 @ 별칭을 많이 사용하므로 마이그레이션 필요할 경우 적용 */
+
+      /* TODO: web app 내부에서 @ 별칭을 많이 사용하므로 점진적으로 @web 적용 후 @ 별칭 제거 */
+      '@web': join(__dirname, '../../web'),
       '@': join(__dirname, '../../web'),
     };
 

--- a/apps/web/components/product-register/ImageUpload.tsx
+++ b/apps/web/components/product-register/ImageUpload.tsx
@@ -4,9 +4,8 @@ import { useState, useRef, useEffect } from 'react';
 
 import { Icon, Thumbnail } from '@repo/ui/components';
 
-import { validateMultipleImages } from '@/lib/validations/image';
-
-import { PRODUCT_MAX_IMAGES } from '@/constants';
+import { PRODUCT_MAX_IMAGES } from '@web/constants';
+import { validateMultipleImages } from '@web/lib/validations/image';
 
 interface ImageUploadProps {
   onImagesChange: (images: File[]) => void;

--- a/apps/web/components/product-register/ProductRegisterForm.tsx
+++ b/apps/web/components/product-register/ProductRegisterForm.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@repo/ui/components';
 
-import ImageUpload from '@/components/ui/ImageUpload';
+import { ImageUpload } from '@/components/product-register';
 
 import { useProductForm } from '@/hooks/products';
 

--- a/apps/web/components/product-register/index.ts
+++ b/apps/web/components/product-register/index.ts
@@ -5,3 +5,4 @@ export { default as MinimumPriceField } from './MinimumPriceField';
 export { default as DecreaseUnitField } from './DecreaseUnitField';
 export { default as LocationInfoField } from './LocationInfoField';
 export { default as ProductRegisterForm } from './ProductRegisterForm';
+export { default as ImageUpload } from './ImageUpload';

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -9,6 +9,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
+      "@web/*": ["./*"],
     },
     "types": [
       "kakao.maps.d.ts"


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안



## 📋 작업 내용

설명참고 : #164 


- web app 내 @web 별칭도 사용가능하도록 추가
- docs app의 스토리북 경로 설정 시 @web, @ 2가지 별칭 모두 web app의 경로를 바라보도록 설정 추가

## 🔧 변경 사항

- [x] 📃 docs/.storybook/main.ts
- [x] ⚙️ web/tsconfig.json

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
