### PR TITLE
chore: 모든 작업 브랜치에서 push 할 경우 chromatic.yml 파일 동작하도록 수정 (#163)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,13 +1,12 @@
 name: Chromatic Deployment
 
 on:
-  # PR이 생성되거나 업데이트될 때
+  # PR이 생성되거나 업데이트될 때 (모든 브랜치에서)
   pull_request:
-    branches: [main, develop]
 
-  # main 브랜치에 push될 때
+  # push될 때 (주요 브랜치만)
   push:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   # 변경사항 감지


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

현재 피처 브랜치 pr 시 자동으로 크로마틱 배포가 동작하지 않는 이슈 개선

## 📋 작업 내용

- 이벤트 트리거 기준 pr 에 해당하는 브랜치를 main, develop으로만 지정 -> 모든 브랜치 동작하도록 비워둠
- push는 main 브랜치와 develop 브랜치 기준으로 수정

## 🔧 변경 사항

- [x] 📃 chromatic.yml

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
