### PR TITLE
refactor: icon button과 icon 스토리에서 하드코딩된 옵션값을 리팩토링 (#196)

### DIFF
--- a/packages/ui/src/design-system/base-components/IconButton/IconButton.stories.tsx
+++ b/packages/ui/src/design-system/base-components/IconButton/IconButton.stories.tsx
@@ -1,7 +1,12 @@
 import type { IconName } from '@ui/components/Icons';
+import { ICON_NAME_KEYS, ICON_SIZE_KEYS } from '@ui/components/Icons';
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
-import IconButton from './IconButton';
+import IconButton, {
+  ICON_BUTTON_COLORS_KEYS,
+  ICON_BUTTON_VARIANTS_KEYS,
+  ICON_BUTTON_SIZES_KEYS,
+} from './IconButton';
 
 const meta: Meta<typeof IconButton> = {
   title: 'Design System/Base Components/Icon Button',
@@ -28,27 +33,27 @@ const meta: Meta<typeof IconButton> = {
   argTypes: {
     iconName: {
       control: { type: 'select' },
-      options: ['Bell', 'Bell', 'ArrowLeft', 'Heart', 'Home', 'Export'],
+      options: ICON_NAME_KEYS,
       description: '아이콘 이름',
     },
     iconSize: {
       control: { type: 'select' },
-      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+      options: ICON_SIZE_KEYS,
       description: '아이콘 크기',
     },
     color: {
       control: { type: 'select' },
-      options: ['light', 'darkMode', 'primary', 'secondary', 'danger'],
+      options: ICON_BUTTON_COLORS_KEYS,
       description: '색상 테마',
     },
     variant: {
       control: { type: 'select' },
-      options: ['fulled', 'outlined'],
+      options: ICON_BUTTON_VARIANTS_KEYS,
       description: '스타일 변형',
     },
     buttonSize: {
       control: { type: 'select' },
-      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+      options: ICON_BUTTON_SIZES_KEYS,
       description: '버튼 크기',
     },
     ariaLabel: {

--- a/packages/ui/src/design-system/base-components/IconButton/IconButton.tsx
+++ b/packages/ui/src/design-system/base-components/IconButton/IconButton.tsx
@@ -4,15 +4,19 @@ import { Icon } from '@ui/components';
 import type { IconName, IconSize } from '@ui/components';
 import { cn } from '@ui/utils/cn';
 
+export type IconButtonColor = 'darkMode' | 'lightMode' | 'primary' | 'secondary' | 'danger';
+export type IconButtonVariant = 'fulled' | 'outlined';
+export type IconButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
 interface IconButtonOwnProps<T extends ElementType = 'button'> {
   // div, span은 react-router-dom의 <Link>와 함께 사용할 때 <a> 태그 중복 방지를 위해 사용.
   // Next.js의 <Link>는 자식이 <a> 태그일 경우 a 요소 중복이 자동 제거됨. <a> 태그 사용 권장. 불 필요한 div, span 사용 방지.
   as?: T;
 
   // 스타일 정의
-  color: 'darkMode' | 'lightMode' | 'primary' | 'secondary' | 'danger';
-  variant: 'fulled' | 'outlined';
-  buttonSize: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  color: IconButtonColor;
+  variant: IconButtonVariant;
+  buttonSize: IconButtonSize;
   className?: string;
   isTransparent?: boolean;
 
@@ -27,7 +31,7 @@ type IconButtonProps<T extends ElementType = 'button'> = IconButtonOwnProps<T> &
 
 export type { IconButtonProps };
 
-const SIZES = {
+const SIZES: Record<IconButtonSize, string> = {
   xs: 'w-[32px] h-[32px]',
   sm: 'w-[40px] h-[40px]',
   md: 'w-[44px] h-[44px]',
@@ -35,7 +39,7 @@ const SIZES = {
   xl: 'w-[56px] h-[56px]',
 } as const;
 
-const COLORS = {
+const COLORS: Record<IconButtonColor, Record<IconButtonVariant, string>> = {
   lightMode: {
     fulled: 'bg-bg-base text-text-base',
     outlined: 'border border-border-base text-text-base',
@@ -90,5 +94,9 @@ const IconButton = <T extends ElementType = 'button'>({
     </Component>
   );
 };
+
+export const ICON_BUTTON_COLORS_KEYS = Object.keys(COLORS) as IconButtonColor[];
+export const ICON_BUTTON_VARIANTS_KEYS = Object.keys(COLORS.lightMode) as IconButtonVariant[];
+export const ICON_BUTTON_SIZES_KEYS = Object.keys(SIZES) as IconButtonSize[];
 
 export default IconButton;

--- a/packages/ui/src/design-system/base-components/Icons/Icon.tsx
+++ b/packages/ui/src/design-system/base-components/Icons/Icon.tsx
@@ -2,7 +2,7 @@ import { cn } from '@ui/utils/cn';
 import { ICONS } from './assets/Icons';
 
 export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-type IconColor =
+export type IconColor =
   | 'default'
   | 'inverse'
   | 'info'
@@ -50,5 +50,9 @@ export const Icon = ({ name, size = 'md', color = 'default', className, ...props
 
   return <IconComponent className={cn(sizeClass, colorClass, className)} {...props} />;
 };
+
+export const ICON_NAME_KEYS = Object.keys(ICONS) as IconName[];
+export const ICON_COLOR_KEYS = Object.keys(COLORS) as IconColor[];
+export const ICON_SIZE_KEYS = Object.keys(SIZES) as IconSize[];
 
 export default Icon;

--- a/packages/ui/src/design-system/base-components/Icons/Icons.stories.tsx
+++ b/packages/ui/src/design-system/base-components/Icons/Icons.stories.tsx
@@ -1,8 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
-import { Icon, type IconName } from './Icon';
-import { ICONS } from './assets/Icons';
-
-const ICON_NAMES = Object.keys(ICONS) as IconName[];
+import { Icon, ICON_COLOR_KEYS, ICON_NAME_KEYS, ICON_SIZE_KEYS } from './Icon';
 
 const meta: Meta<typeof Icon> = {
   title: 'Design System/Base Components/Icons',
@@ -30,12 +27,12 @@ const meta: Meta<typeof Icon> = {
   argTypes: {
     name: {
       control: 'select',
-      options: ICON_NAMES,
+      options: ICON_NAME_KEYS,
       description: '렌더링할 아이콘의 이름',
     },
     size: {
       control: 'select',
-      options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'],
+      options: ICON_SIZE_KEYS,
       description: '아이콘의 크기 (디자인 토큰 기반)',
       table: {
         defaultValue: { summary: 'md' },
@@ -43,7 +40,7 @@ const meta: Meta<typeof Icon> = {
     },
     color: {
       control: 'select',
-      options: ['default', 'inverse', 'info', 'primary', 'secondary', 'success', 'danger', 'error'],
+      options: ICON_COLOR_KEYS,
       description: '아이콘의 색상 (디자인 시스템 컬러 토큰 사용)',
       table: {
         defaultValue: { summary: 'default' },
@@ -54,7 +51,7 @@ const meta: Meta<typeof Icon> = {
     },
   },
   args: {
-    name: ICON_NAMES[0],
+    name: ICON_NAME_KEYS[0],
     size: 'md',
     color: 'default',
   },
@@ -78,7 +75,7 @@ export const Playground: Story = {
 export const AllIcons: Story = {
   render: (args) => (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24 }}>
-      {ICON_NAMES.map((iconName) => (
+      {ICON_NAME_KEYS.map((iconName) => (
         <div
           key={iconName}
           style={{

--- a/packages/ui/src/design-system/base-components/Icons/index.ts
+++ b/packages/ui/src/design-system/base-components/Icons/index.ts
@@ -1,2 +1,2 @@
-export { default as Icon } from './Icon';
-export type { IconName, IconSize, IconProps } from './Icon';
+export { default as Icon, ICON_NAME_KEYS, ICON_SIZE_KEYS, ICON_COLOR_KEYS } from './Icon';
+export type { IconName, IconSize, IconColor, IconProps } from './Icon';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

#195 의 테스트용으로 만든 스토리 수정 작업

## 📋 작업 내용

- icon button과 icon 스토리에서 하드코딩된 옵션값을 리팩토링

## 🔧 변경 사항

- [ ] 🎨 Icon, IconButton의 props 값들을 export
- [ ] 🎨 Icon, IconButton의 스토리에서 하드코딩된 옵션 값 제거

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
