### PR TITLE
fix: chromatic.yml 파일에서 chromatic-storybook 단계가 skip 되는 이슈 해결 (#198)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy Storybook to Chromatic
     needs: detect-changes
-    if: needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.web == 'true' || needs.detect-changes.outputs.docs == 'true' || github.ref == 'refs/heads/main'
+    if: needs.detect-changes.outputs.ui-changed == 'true' || needs.detect-changes.outputs.web-changed == 'true' || needs.detect-changes.outputs.docs-changed == 'true' || github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

아래 이미지와 같이 story를 수정하거나 생성했을 때에도 storybook deploy 단계가 스킵되는 현상 해결

<img width="1475" height="415" alt="image" src="https://github.com/user-attachments/assets/d43218c8-31c0-43fd-8bc2-9125f3b71413" />

## 📋 작업 내용

- `detech-changes` 단계에서 발생하는 output의 디렉토리 명과 `chromatic-storybook` 단계의 if 문의 디렉토리 명이 일치하지 않아서 생기는 문제이므로 if 문 수정
  <img width="920" height="569" alt="image" src="https://github.com/user-attachments/assets/846701a8-c78e-4c5a-a995-09caf89a1a15" />

- `detect-changes` 에서 생기는 outputs의 디렉토리들은 ui-changed, web-changed, docs-changed
  ```yml
  jobs:
    # 변경사항 감지
    detect-changes:
      runs-on: ubuntu-latest
      outputs:
        ui-changed: ${{ steps.changes.outputs.ui }}
        web-changed: ${{ steps.changes.outputs.web }}
        docs-changed: ${{ steps.changes.outputs.docs }}
  ```

- `chromatic-storybook` if 문 수정 전
  ```yml
    # 통합 스토리북 배포 (모든 컴포넌트 변경시)
    chromatic-storybook:
      runs-on: ubuntu-latest
      name: Deploy Storybook to Chromatic
      needs: detect-changes
      if: needs.detect-changes.outputs.ui== 'true' || needs.detect-changes.outputs.web== 'true' || needs.detect-changes.outputs.docs== 'true' || github.ref == 'refs/heads/main'
  ``` 

- `chromatic-storybook` if 문 수정 후
  ```yml
    # 통합 스토리북 배포 (모든 컴포넌트 변경시)
    chromatic-storybook:
      runs-on: ubuntu-latest
      name: Deploy Storybook to Chromatic
      needs: detect-changes
      if: needs.detect-changes.outputs.ui-changed== 'true' || needs.detect-changes.outputs.web-changed== 'true' || needs.detect-changes.outputs.docs-changed== 'true' || github.ref == 'refs/heads/main'
  ``` 

## 🔧 변경 사항

- [x] 📃 chromatic.yml

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
