### PR TITLE
feat: 구매내역(입찰내역) 조회 기능 구현 (#212)

### DIFF
--- a/apps/web/app/(pages)/mypage/bids/layout.tsx
+++ b/apps/web/app/(pages)/mypage/bids/layout.tsx
@@ -1,0 +1,22 @@
+import { TopNavigation, PageContainer } from '@web/components/layout';
+
+interface PurchasesLayoutProps {
+  children: React.ReactNode;
+}
+
+const PurchasesLayout = ({ children }: PurchasesLayoutProps) => {
+  return (
+    <div className="h-screen flex flex-col">
+      <TopNavigation
+        title="낙찰내역"
+        showTitle
+        showBackButton
+        showSearchButton={false}
+        showAlarmButton={false}
+      />
+      <PageContainer className="py-lg">{children}</PageContainer>
+    </div>
+  );
+};
+
+export default PurchasesLayout;

--- a/apps/web/app/(pages)/mypage/bids/page.tsx
+++ b/apps/web/app/(pages)/mypage/bids/page.tsx
@@ -1,0 +1,7 @@
+import { BidHistoryContainer } from '@web/components/bid-history';
+
+const BidHistoryPage = () => {
+  return <BidHistoryContainer />;
+};
+
+export default BidHistoryPage;

--- a/apps/web/app/api/bids/my/route.ts
+++ b/apps/web/app/api/bids/my/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+
+import { getBidHistory } from '@web/services/bids/server';
+import { getAuthenticatedUser } from '@web/utils/auth/server';
+
+/**
+ * 사용자별 입찰 내역 조회 API
+ * GET /api/bids/my
+ */
+export async function GET() {
+  try {
+    // 사용자 인증 확인
+    const authResult = await getAuthenticatedUser();
+    if (!authResult.success) {
+      return NextResponse.json({ error: '로그인이 필요합니다' }, { status: 401 });
+    }
+
+    // 서비스 함수를 통한 입찰 내역 조회
+    const bidHistory = await getBidHistory(authResult.userId!);
+
+    return NextResponse.json(bidHistory);
+  } catch (error) {
+    console.error('입찰 내역 조회 오류:', error);
+
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ error: '입찰 내역 조회 중 오류가 발생했습니다' }, { status: 500 });
+  }
+}

--- a/apps/web/components/bid-history/BidHistoryCard.tsx
+++ b/apps/web/components/bid-history/BidHistoryCard.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type { BidWithProduct } from '@web/types';
+import { formatDate } from '@web/utils/date';
+
+import ProductCard from '../products/ProductCard';
+
+interface BidHistoryCardProps {
+  bid: BidWithProduct;
+}
+
+const BidHistoryCard = ({ bid }: BidHistoryCardProps) => {
+  const { product } = bid;
+
+  if (!product) return null;
+
+  const mainImage = product.images?.[0];
+
+  return (
+    <div className="relative">
+      <ProductCard
+        productId={Number(product.product_id)}
+        imgUrl={mainImage?.image_url || ''}
+        title={product.title}
+        startPrice={product.start_price}
+        minPrice={bid.bid_price}
+        decreaseUnit={product.decrease_unit}
+        auctionStartedAt={product.auction_started_at || product.created_at}
+        status={product.status}
+        createdAt={product.created_at}
+        region={product.location_region}
+        isShowProductBadge={false}
+      />
+
+      {/* 입찰 시간 */}
+      <div className="absolute bottom-0 right-0 z-10 bg-bg-dark/70 rounded px-xs">
+        <span className="text-xs text-text-inverse">{formatDate(bid.created_at)} 낙찰</span>
+      </div>
+    </div>
+  );
+};
+
+export default BidHistoryCard;

--- a/apps/web/components/bid-history/BidHistoryContainer.tsx
+++ b/apps/web/components/bid-history/BidHistoryContainer.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useBidHistory, useBidFilter } from '@web/hooks';
+
+import ProductListSkeleton from '../products/ProductListSkeleton';
+
+import BidHistoryCard from './BidHistoryCard';
+import BidHistoryEmptyState from './BidHistoryEmptyState';
+import BidHistoryFilter from './BidHistoryFilter';
+import BidHistorySearchEmpty from './BidHistorySearchEmpty';
+
+/**
+ * 낙찰내역 클라이언트 컨테이너
+ * 데이터 로딩, 필터링, 상태 관리를 담당
+ */
+const BidHistoryContainer = () => {
+  const { data: bidHistory, isLoading, error } = useBidHistory();
+
+  const {
+    searchTerm,
+    selectedYear,
+    selectedMonth,
+    filteredBids,
+    filteredCount,
+    setSearchTerm,
+    setSelectedYear,
+    setSelectedMonth,
+    clearFilters,
+  } = useBidFilter({ bids: bidHistory?.bids || [] });
+
+  if (isLoading) return <ProductListSkeleton />;
+  if (error)
+    return (
+      <div className="py-lg text-center text-text-info">데이터를 불러오는데 실패했습니다.</div>
+    );
+  if (!bidHistory?.bids?.length) return <BidHistoryEmptyState />;
+
+  const hasFilters = searchTerm || selectedMonth;
+  const showEmpty = filteredCount === 0 && hasFilters;
+
+  return (
+    <div className="flex flex-col gap-md">
+      <BidHistoryFilter
+        onDateChange={(year, month) => {
+          setSelectedYear(year);
+          setSelectedMonth(month);
+        }}
+        onSearchChange={(searchTerm) => setSearchTerm(searchTerm)}
+        initialSearchValue=""
+        initialYear={selectedYear}
+        initialMonth={selectedMonth}
+      />
+
+      {showEmpty ? (
+        <BidHistorySearchEmpty onClearSearch={clearFilters} />
+      ) : (
+        <div className="grid gap-sm">
+          {filteredBids.map((bid) => (
+            <BidHistoryCard key={bid.bid_id} bid={bid} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BidHistoryContainer;

--- a/apps/web/components/bid-history/BidHistoryDateFilter.tsx
+++ b/apps/web/components/bid-history/BidHistoryDateFilter.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { Button, BottomSheet, Icon } from '@repo/ui/components';
+
+import { useBidDateFilter } from '@web/hooks';
+
+interface BidHistoryDateFilterProps {
+  onChange?: (year: string, month: string) => void;
+  initialYear?: string;
+  initialMonth?: string;
+}
+
+export const BidHistoryDateFilter = ({
+  onChange,
+  initialYear,
+  initialMonth,
+}: BidHistoryDateFilterProps) => {
+  const {
+    selectedYear,
+    selectedMonth,
+    yearOptions,
+    monthOptions,
+    isYearSheetOpen,
+    isMonthSheetOpen,
+    onYearSheetOpen,
+    onMonthSheetOpen,
+    onYearSelect,
+    onMonthSelect,
+    onClear,
+  } = useBidDateFilter({ onChange, initialYear, initialMonth });
+
+  const hasDateFilters =
+    (selectedYear && selectedYear !== '') || (selectedMonth && selectedMonth !== '');
+
+  return (
+    <>
+      <div className="flex items-center gap-sm">
+        <Button
+          variant="outlined"
+          color="lightMode"
+          size="xs"
+          isFullWidth={false}
+          onClick={() => onYearSheetOpen(true)}
+          className="flex items-center justify-between gap-xs min-w-[72px]"
+        >
+          <span>{selectedYear === '' ? '전체' : selectedYear ? `${selectedYear}년` : '연도'}</span>
+          <Icon name="ArrowDown" size="xs" />
+        </Button>
+
+        <Button
+          variant="outlined"
+          color="lightMode"
+          size="xs"
+          isFullWidth={false}
+          onClick={() => onMonthSheetOpen(true)}
+          isDisabled={false}
+          className="flex items-center justify-between gap-xs min-w-[60px]"
+        >
+          <span>{selectedMonth === '' ? '전체' : selectedMonth ? `${selectedMonth}월` : '월'}</span>
+          <Icon name="ArrowDown" size="xs" />
+        </Button>
+
+        {hasDateFilters && (
+          <Button
+            variant="outlined"
+            color="lightMode"
+            size="xs"
+            isFullWidth={false}
+            onClick={onClear}
+          >
+            초기화
+          </Button>
+        )}
+      </div>
+
+      <BottomSheet
+        isOpen={isYearSheetOpen}
+        onClose={() => onYearSheetOpen(false)}
+        title="연도 선택"
+      >
+        <div className="space-y-2">
+          <Button
+            color="lightMode"
+            variant="fulled"
+            size="sm"
+            onClick={() => onYearSelect('')}
+            className="w-full justify-start"
+          >
+            전체
+          </Button>
+          {yearOptions.map((year) => (
+            <Button
+              key={year}
+              color="lightMode"
+              variant="fulled"
+              size="sm"
+              onClick={() => onYearSelect(year)}
+              className="w-full justify-start"
+            >
+              {year}년
+            </Button>
+          ))}
+        </div>
+      </BottomSheet>
+
+      <BottomSheet
+        isOpen={isMonthSheetOpen}
+        onClose={() => onMonthSheetOpen(false)}
+        title="월 선택"
+      >
+        <div className="space-y-2">
+          <Button
+            color="lightMode"
+            variant="fulled"
+            size="sm"
+            onClick={() => onMonthSelect('')}
+            className="w-full justify-start"
+          >
+            전체
+          </Button>
+          {monthOptions.map((month) => (
+            <Button
+              key={month}
+              color="lightMode"
+              variant="fulled"
+              size="sm"
+              onClick={() => onMonthSelect(month)}
+              className="w-full justify-start"
+            >
+              {month}월
+            </Button>
+          ))}
+        </div>
+      </BottomSheet>
+    </>
+  );
+};

--- a/apps/web/components/bid-history/BidHistoryEmptyState.tsx
+++ b/apps/web/components/bid-history/BidHistoryEmptyState.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Button, Icon } from '@repo/ui/components';
+
+import { useAppNavigation } from '@web/hooks';
+
+/**
+ * 입찰내역 빈 상태 컴포넌트
+ */
+const BidHistoryEmptyState = () => {
+  const { goHome } = useAppNavigation();
+
+  return (
+    <div className="flex flex-col items-center justify-center py-xl px-container">
+      <div className="w-16 h-16 rounded-full bg-bg-base flex items-center justify-center mb-md">
+        <Icon name="ShoppingBag" size="lg" className="text-text-primary" />
+      </div>
+
+      <h3 className="font-style-large mb-xs">입찰한 상품이 없어요</h3>
+
+      <p className="text-center mb-xl font-style-medium text-text-info">
+        마음에 드는 상품에 입찰해보세요!
+        <br />
+        입찰 성공 시 이곳에서 확인할 수 있어요.
+      </p>
+
+      <Button onClick={goHome}>상품 둘러보기</Button>
+    </div>
+  );
+};
+
+export default BidHistoryEmptyState;

--- a/apps/web/components/bid-history/BidHistoryFilter.tsx
+++ b/apps/web/components/bid-history/BidHistoryFilter.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { BidHistoryDateFilter } from './BidHistoryDateFilter';
+import { BidHistorySearchFilter } from './BidHistorySearchFilter';
+
+interface BidHistoryFilterProps {
+  onDateChange?: (year: string, month: string) => void;
+  onSearchChange?: (searchTerm: string) => void;
+  initialSearchValue?: string;
+  initialYear?: string;
+  initialMonth?: string;
+}
+
+const BidHistoryFilter = ({
+  onDateChange,
+  onSearchChange,
+  initialSearchValue,
+  initialYear,
+  initialMonth,
+}: BidHistoryFilterProps) => {
+  return (
+    <div className="flex flex-col gap-md">
+      <BidHistoryDateFilter
+        onChange={onDateChange}
+        initialYear={initialYear}
+        initialMonth={initialMonth}
+      />
+
+      <BidHistorySearchFilter
+        onSearch={onSearchChange}
+        initialValue={initialSearchValue}
+        placeholder="상품명으로 검색..."
+      />
+    </div>
+  );
+};
+
+export default BidHistoryFilter;

--- a/apps/web/components/bid-history/BidHistorySearchEmpty.tsx
+++ b/apps/web/components/bid-history/BidHistorySearchEmpty.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Button, Icon } from '@repo/ui/components';
+
+interface BidHistorySearchEmptyProps {
+  onClearSearch: () => void;
+}
+
+/**
+ * 입찰내역 검색 결과 없음 상태 컴포넌트
+ */
+const BidHistorySearchEmpty = ({ onClearSearch }: BidHistorySearchEmptyProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center py-xl text-center">
+      <div className="w-12 h-12 rounded-full bg-bg-base flex items-center justify-center mb-md">
+        <Icon name="Search" size="md" className="text-text-primary" />
+      </div>
+
+      <h3 className="font-style-large mb-xs">검색 결과가 없어요</h3>
+
+      <p className="text-center mb-xl font-style-medium text-text-info">
+        검색어에 맞는 입찰 내역이 없습니다.
+        <br />
+        다른 키워드로 검색해보세요.
+      </p>
+
+      <Button onClick={onClearSearch} variant="outlined" size="sm">
+        전체 보기
+      </Button>
+    </div>
+  );
+};
+
+export default BidHistorySearchEmpty;

--- a/apps/web/components/bid-history/BidHistorySearchFilter.tsx
+++ b/apps/web/components/bid-history/BidHistorySearchFilter.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Input, IconButton } from '@repo/ui/components';
+
+import { useBidSearchFilter } from '@web/hooks';
+
+interface BidHistorySearchFilterProps {
+  onSearch?: (searchTerm: string) => void;
+  initialValue?: string;
+  placeholder?: string;
+}
+
+export const BidHistorySearchFilter = ({
+  onSearch,
+  initialValue,
+  placeholder = '상품명으로 검색...',
+}: BidHistorySearchFilterProps) => {
+  const { inputValue, onInputChange, onSearchSubmit, onClear } = useBidSearchFilter({
+    onSearch,
+    initialValue,
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSearchSubmit();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="w-full">
+      <div className="relative">
+        <Input
+          type="text"
+          placeholder={placeholder}
+          value={inputValue}
+          onChange={(e) => onInputChange(e.target.value)}
+          className="pr-10"
+        />
+
+        {inputValue && (
+          <IconButton
+            type="button"
+            iconName="Cancel"
+            iconSize="sm"
+            color="lightMode"
+            variant="outlined"
+            buttonSize="sm"
+            ariaLabel="검색어 지우기"
+            onClick={onClear}
+            className="absolute right-2 top-1/2 -translate-y-1/2"
+            isTransparent
+          />
+        )}
+      </div>
+    </form>
+  );
+};

--- a/apps/web/components/bid-history/index.ts
+++ b/apps/web/components/bid-history/index.ts
@@ -1,0 +1,1 @@
+export { default as BidHistoryContainer } from './BidHistoryContainer';

--- a/apps/web/components/mypage/TradingMenu.tsx
+++ b/apps/web/components/mypage/TradingMenu.tsx
@@ -7,13 +7,13 @@ const TradingMenu = () => {
   const tradingMenuItems: MypageMenuItemProps[] = [
     {
       icon: 'Export',
-      title: '판매내역',
+      title: '출품내역',
       href: PAGE_ROUTES.MYPAGE.SALES,
     },
     {
       icon: 'ShoppingBag',
-      title: '구매내역',
-      href: PAGE_ROUTES.MYPAGE.PURCHASES,
+      title: '낙찰내역',
+      href: PAGE_ROUTES.MYPAGE.BIDS,
     },
     {
       icon: 'Heart',

--- a/apps/web/constants/query-key.ts
+++ b/apps/web/constants/query-key.ts
@@ -6,6 +6,9 @@ export const MY_INFO_QUERY_KEY = ['my-info'] as const;
 
 // 사용자 상품 관련
 export const MY_PRODUCTS_QUERY_KEY = {
-  all: () => ['my-products'] as const,
-  byStatus: (status?: ProductStatus) => ['my-products', status] as const,
+  ALL: ['my-products'] as const,
+  BY_STATUS: (status?: ProductStatus) => ['my-products', status] as const,
 };
+
+// 사용자 입찰 관련
+export const BID_HISTORY_QUERY_KEY = ['bid-history'] as const;

--- a/apps/web/constants/routes/pages.ts
+++ b/apps/web/constants/routes/pages.ts
@@ -27,7 +27,7 @@ export const PAGE_ROUTES = {
     NOTIFICATIONS: '/mypage/notifications',
     ACCOUNT: '/mypage/account',
     SALES: '/mypage/sales',
-    PURCHASES: '/mypage/purchases',
+    BIDS: '/mypage/bids',
     FAVORITES: '/mypage/favorites',
   },
 } as const;

--- a/apps/web/hooks/bids/index.ts
+++ b/apps/web/hooks/bids/index.ts
@@ -1,0 +1,4 @@
+export { useBidHistory } from './useBidHistory';
+export { useBidFilter } from './useBidFilter';
+export { useBidDateFilter } from './useBidDateFilter';
+export { useBidSearchFilter } from './useBidSearchFilter';

--- a/apps/web/hooks/bids/useBidDateFilter.ts
+++ b/apps/web/hooks/bids/useBidDateFilter.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+
+interface UseBidDateFilterProps {
+  onChange?: (year: string, month: string) => void;
+  initialYear?: string;
+  initialMonth?: string;
+}
+
+export const useBidDateFilter = ({
+  onChange,
+  initialYear = '',
+  initialMonth = '',
+}: UseBidDateFilterProps = {}) => {
+  const currentYear = new Date().getFullYear().toString();
+
+  const [selectedYear, setSelectedYear] = useState<string>(initialYear);
+  const [selectedMonth, setSelectedMonth] = useState<string>(initialMonth);
+  const [isYearSheetOpen, setIsYearSheetOpen] = useState(false);
+  const [isMonthSheetOpen, setIsMonthSheetOpen] = useState(false);
+
+  // 사용 가능한 연도/월 옵션 생성
+  const { yearOptions, monthOptions } = useMemo(() => {
+    // 연도: 최근 5년만 제공
+    const currentYearNum = new Date().getFullYear();
+    const recentYears = Array.from({ length: 5 }, (_, i) => (currentYearNum - i).toString());
+
+    // 월: 선택된 연도에 따라 결정
+    const months = new Set<string>();
+
+    if (selectedYear === '' || selectedYear === currentYear) {
+      // 전체 선택이거나 현재 연도일 때는 현재 월까지만
+      for (let i = 1; i <= new Date().getMonth() + 1; i++) {
+        months.add(i.toString().padStart(2, '0'));
+      }
+    } else {
+      // 다른 연도일 때는 1~12월 모두
+      for (let i = 1; i <= 12; i++) {
+        months.add(i.toString().padStart(2, '0'));
+      }
+    }
+
+    return {
+      yearOptions: recentYears,
+      monthOptions: Array.from(months).sort((a, b) => b.localeCompare(a)),
+    };
+  }, [selectedYear, currentYear]);
+
+  const handleYearSelect = (year: string) => {
+    setSelectedYear(year);
+    setSelectedMonth(''); // 연도 변경시 월 초기화
+    setIsYearSheetOpen(false);
+    onChange?.(year, '');
+  };
+
+  const handleMonthSelect = (month: string) => {
+    setSelectedMonth(month);
+    setIsMonthSheetOpen(false);
+    onChange?.(selectedYear, month);
+  };
+
+  const handleClear = () => {
+    setSelectedYear('');
+    setSelectedMonth('');
+    onChange?.('', '');
+  };
+
+  return {
+    selectedYear,
+    selectedMonth,
+    yearOptions,
+    monthOptions,
+    isYearSheetOpen,
+    isMonthSheetOpen,
+    onYearSheetOpen: setIsYearSheetOpen,
+    onMonthSheetOpen: setIsMonthSheetOpen,
+    onYearSelect: handleYearSelect,
+    onMonthSelect: handleMonthSelect,
+    onClear: handleClear,
+  };
+};

--- a/apps/web/hooks/bids/useBidFilter.ts
+++ b/apps/web/hooks/bids/useBidFilter.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+
+import type { BidWithProduct } from '@web/types';
+
+interface UseBidFilterProps {
+  bids: BidWithProduct[];
+}
+
+export const useBidFilter = ({ bids }: UseBidFilterProps) => {
+  const currentYear = new Date().getFullYear().toString();
+
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedYear, setSelectedYear] = useState<string>('');
+  const [selectedMonth, setSelectedMonth] = useState<string>('');
+
+  // 필터링된 입찰 내역
+  const filteredBids = useMemo(() => {
+    return bids.filter((bid) => {
+      // 검색어 필터
+      if (searchTerm && !bid.product.title.toLowerCase().includes(searchTerm.toLowerCase())) {
+        return false;
+      }
+
+      // 연도/월 필터
+      const bidDate = new Date(bid.created_at);
+      const bidYear = bidDate.getFullYear().toString();
+      const bidMonth = (bidDate.getMonth() + 1).toString().padStart(2, '0');
+
+      if (selectedYear && selectedYear !== bidYear) return false;
+      if (selectedMonth && selectedMonth !== bidMonth) return false;
+
+      return true;
+    });
+  }, [bids, searchTerm, selectedYear, selectedMonth]);
+
+  return {
+    searchTerm,
+    selectedYear,
+    selectedMonth,
+    filteredBids,
+    filteredCount: filteredBids.length,
+    setSearchTerm,
+    setSelectedYear: (year: string) => {
+      setSelectedYear(year);
+      setSelectedMonth(''); // 연도 변경시 월 초기화
+    },
+    setSelectedMonth,
+    clearFilters: () => {
+      setSearchTerm('');
+      setSelectedYear('');
+      setSelectedMonth('');
+    },
+  };
+};

--- a/apps/web/hooks/bids/useBidHistory.ts
+++ b/apps/web/hooks/bids/useBidHistory.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { BID_HISTORY_QUERY_KEY } from '@web/constants';
+import { fetchBidHistory } from '@web/services/bids/client';
+
+/**
+ * 입찰 내역 조회 훅
+ */
+export const useBidHistory = () => {
+  return useQuery({
+    queryKey: BID_HISTORY_QUERY_KEY,
+    queryFn: () => fetchBidHistory(),
+  });
+};

--- a/apps/web/hooks/bids/useBidSearchFilter.ts
+++ b/apps/web/hooks/bids/useBidSearchFilter.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useState } from 'react';
+
+interface UseBidSearchFilterProps {
+  onSearch?: (searchTerm: string) => void;
+  initialValue?: string;
+}
+
+export const useBidSearchFilter = ({
+  onSearch,
+  initialValue = '',
+}: UseBidSearchFilterProps = {}) => {
+  const [inputValue, setInputValue] = useState(initialValue);
+
+  const handleInputChange = (value: string) => {
+    setInputValue(value);
+  };
+
+  const handleSearchSubmit = () => {
+    const trimmedValue = inputValue.trim();
+    onSearch?.(trimmedValue);
+  };
+
+  const handleClear = () => {
+    setInputValue('');
+    onSearch?.('');
+  };
+
+  return {
+    inputValue,
+    onInputChange: handleInputChange,
+    onSearchSubmit: handleSearchSubmit,
+    onClear: handleClear,
+  };
+};

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './location';
 export * from './products';
 export * from './my-info';
 export * from './search';
+export * from './bids';

--- a/apps/web/hooks/products/useMyProducts.ts
+++ b/apps/web/hooks/products/useMyProducts.ts
@@ -13,7 +13,7 @@ interface UseMyProductsProps {
 
 export const useMyProducts = ({ status }: UseMyProductsProps = {}) => {
   return useQuery<ProductsAPIResponse>({
-    queryKey: MY_PRODUCTS_QUERY_KEY.byStatus(status),
+    queryKey: MY_PRODUCTS_QUERY_KEY.BY_STATUS(status),
     queryFn: () => fetchMyProducts(status),
   });
 };

--- a/apps/web/hooks/products/useProductActions.ts
+++ b/apps/web/hooks/products/useProductActions.ts
@@ -22,7 +22,7 @@ export const useProductActions = ({ productId, title }: UseProductActionsProps) 
 
   const invalidateQueries = async () => {
     await queryClient.invalidateQueries({
-      queryKey: MY_PRODUCTS_QUERY_KEY.all(),
+      queryKey: MY_PRODUCTS_QUERY_KEY.ALL,
     });
   };
 

--- a/apps/web/services/bids/client/fetchBidHistory.ts
+++ b/apps/web/services/bids/client/fetchBidHistory.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { API_ROUTES } from '@web/constants';
+
+import type { BidHistoryResponse } from '@web/types';
+
+/**
+ * 사용자의 입찰 내역을 조회하는 클라이언트 서비스 함수
+ */
+export const fetchBidHistory = async (): Promise<BidHistoryResponse> => {
+  try {
+    const response = await fetch(`${API_ROUTES.BIDS}/my`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.error || '입찰 내역 조회에 실패했습니다');
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error('입찰 내역 조회 클라이언트 오류:', error);
+    throw error;
+  }
+};

--- a/apps/web/services/bids/client/index.ts
+++ b/apps/web/services/bids/client/index.ts
@@ -1,0 +1,1 @@
+export { fetchBidHistory } from './fetchBidHistory';

--- a/apps/web/services/bids/server/getBidHistory.ts
+++ b/apps/web/services/bids/server/getBidHistory.ts
@@ -1,0 +1,58 @@
+import { Prisma } from '@prisma/client';
+
+
+import { prisma } from '@web/lib/prisma';
+import type { BidHistoryResponse } from '@web/types';
+import { convertToBidHistoryResponse } from '@web/utils/bids';
+
+/**
+ * 사용자의 입찰 내역 조회 서비스 함수
+ * @param userId - 사용자 ID
+ * @param tx - Prisma 트랜잭션 클라이언트 (옵션)
+ */
+export const getBidHistory = async (
+  userId: string,
+  tx?: Prisma.TransactionClient
+): Promise<BidHistoryResponse> => {
+  const db = tx || prisma;
+
+  try {
+    // 입찰 내역 조회 (상품 정보 포함)
+    const bids = await db.bids.findMany({
+      where: {
+        bidder_user_id: userId,
+      },
+      include: {
+        products: {
+          include: {
+            product_images: {
+              select: {
+                image_id: true,
+                image_url: true,
+                image_order: true,
+              },
+              orderBy: { image_order: 'asc' },
+            },
+          },
+        },
+      },
+      orderBy: {
+        created_at: 'desc',
+      },
+    });
+
+    // 응답 데이터 변환
+    const bidHistory: BidHistoryResponse = convertToBidHistoryResponse(bids);
+
+    return bidHistory;
+  } catch (error) {
+    console.error('입찰 내역 조회 서비스 오류:', error);
+
+    // Prisma 오류 처리
+    if (error instanceof Error && error.message.includes('Prisma')) {
+      throw new Error('데이터베이스 오류가 발생했습니다');
+    }
+
+    throw new Error('입찰 내역 조회 중 오류가 발생했습니다');
+  }
+};

--- a/apps/web/services/bids/server/index.ts
+++ b/apps/web/services/bids/server/index.ts
@@ -1,1 +1,2 @@
 export * from './createBid';
+export * from './getBidHistory';

--- a/apps/web/types/bid/api.ts
+++ b/apps/web/types/bid/api.ts
@@ -1,0 +1,9 @@
+import type { BidWithProduct } from './domain';
+
+/**
+ * 입찰 내역 조회 API 응답
+ */
+export interface BidHistoryResponse {
+  /** 입찰 목록 */
+  bids: BidWithProduct[];
+}

--- a/apps/web/types/bid/domain.ts
+++ b/apps/web/types/bid/domain.ts
@@ -1,0 +1,34 @@
+import type { ProductStatus } from '@/types/product';
+
+/**
+ * 입찰 도메인 타입 정의
+ */
+export interface Bid {
+  bid_id: string;
+  product_id: string;
+  bidder_user_id: string;
+  bid_price: number;
+  created_at: string;
+}
+
+/**
+ * 입찰과 관련 상품 정보를 포함한 확장 타입 (입찰내역 전용)
+ */
+export interface BidWithProduct extends Bid {
+  product: {
+    product_id: string;
+    title: string;
+    start_price: number;
+    current_price: number;
+    decrease_unit: number;
+    status: ProductStatus;
+    location_region: string;
+    created_at: string;
+    auction_started_at?: string;
+    images: Array<{
+      image_id: string;
+      image_url: string;
+      is_main: boolean;
+    }>;
+  };
+}

--- a/apps/web/types/bid/index.ts
+++ b/apps/web/types/bid/index.ts
@@ -1,0 +1,2 @@
+export type { Bid, BidWithProduct } from './domain';
+export type { BidHistoryResponse } from './api';

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -3,3 +3,4 @@ export type * from './image';
 export type * from './product';
 export type * from './chat';
 export type * from './my-info';
+export type * from './bid';

--- a/apps/web/utils/bids/index.ts
+++ b/apps/web/utils/bids/index.ts
@@ -1,0 +1,1 @@
+export * from './mapBidHistoryResponse';

--- a/apps/web/utils/bids/mapBidHistoryResponse.ts
+++ b/apps/web/utils/bids/mapBidHistoryResponse.ts
@@ -1,0 +1,94 @@
+import { PRODUCT_STATUS, PRODUCT_STATUS_VALUES } from '@web/constants';
+import type { BidWithProduct, BidHistoryResponse, ProductStatus } from '@web/types';
+
+// Prisma 결과 타입 정의
+interface PrismaBidWithProduct {
+  bid_id: bigint;
+  product_id: bigint;
+  bidder_user_id: string;
+  bid_price: { toNumber(): number } | number | bigint;
+  created_at: Date;
+  products: {
+    product_id: bigint;
+    title: string;
+    description: string;
+    start_price: { toNumber(): number } | number | bigint;
+    current_price?: { toNumber(): number } | number | bigint;
+    decrease_unit: { toNumber(): number } | number | bigint;
+    status: string;
+    region: string;
+    detail_address: string;
+    view_count: number;
+    created_at: Date;
+    updated_at: Date | null;
+    seller_user_id: string;
+    auction_started_at: Date | null;
+    product_images: Array<{
+      image_id: bigint;
+      image_url: string;
+      image_order: number;
+    }>;
+  };
+}
+
+// 타입 가드 함수
+const isValidProductStatus = (status: string): status is ProductStatus => {
+  return PRODUCT_STATUS_VALUES.includes(status as ProductStatus);
+};
+
+// 단일 Bid 변환 함수
+const convertToBidWithProduct = (bid: PrismaBidWithProduct): BidWithProduct => {
+  return {
+    bid_id: bid.bid_id.toString(),
+    product_id: bid.product_id.toString(),
+    bidder_user_id: bid.bidder_user_id,
+    bid_price:
+      typeof bid.bid_price === 'number'
+        ? bid.bid_price
+        : typeof bid.bid_price === 'bigint'
+          ? Number(bid.bid_price)
+          : bid.bid_price.toNumber(),
+    created_at: bid.created_at.toISOString(),
+    product: {
+      product_id: bid.products.product_id.toString(),
+      title: bid.products.title,
+      start_price:
+        typeof bid.products.start_price === 'number'
+          ? bid.products.start_price
+          : typeof bid.products.start_price === 'bigint'
+            ? Number(bid.products.start_price)
+            : bid.products.start_price.toNumber(),
+      current_price: bid.products.current_price
+        ? typeof bid.products.current_price === 'number'
+          ? bid.products.current_price
+          : typeof bid.products.current_price === 'bigint'
+            ? Number(bid.products.current_price)
+            : bid.products.current_price.toNumber()
+        : 0,
+      decrease_unit:
+        typeof bid.products.decrease_unit === 'number'
+          ? bid.products.decrease_unit
+          : typeof bid.products.decrease_unit === 'bigint'
+            ? Number(bid.products.decrease_unit)
+            : bid.products.decrease_unit.toNumber(),
+      status: isValidProductStatus(bid.products.status)
+        ? bid.products.status
+        : PRODUCT_STATUS.READY,
+      location_region: bid.products.region,
+      created_at: bid.products.created_at.toISOString(),
+      auction_started_at: bid.products.auction_started_at?.toISOString(),
+      images: bid.products.product_images.map((image) => ({
+        image_id: image.image_id.toString(),
+        image_url: image.image_url,
+        is_main: image.image_order === 0, // 첫 번째 이미지를 메인으로 처리
+      })),
+    },
+  };
+};
+
+// 입찰 내역 목록 변환 함수
+export const convertToBidHistoryResponse = (bids: PrismaBidWithProduct[]): BidHistoryResponse => {
+  return {
+    bids: bids.map(convertToBidWithProduct),
+  };
+};

--- a/apps/web/utils/date/formatDate.ts
+++ b/apps/web/utils/date/formatDate.ts
@@ -1,0 +1,48 @@
+/**
+ * ISO 8601 날짜 문자열을 yyyy.mm.dd 형식으로 변환
+ * @param dateString - ISO 8601 형식의 날짜 문자열 (예: "2025-07-22T16:42:22.425Z")
+ * @returns yyyy.mm.dd 형식의 문자열 (예: "2025.07.22")
+ */
+export const formatDate = (dateString: string): string => {
+  try {
+    const date = new Date(dateString);
+
+    // 유효한 날짜인지 확인
+    if (isNaN(date.getTime())) {
+      return dateString; // 유효하지 않은 경우 원본 반환
+    }
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+
+    return `${year}.${month}.${day}`;
+  } catch {
+    return dateString; // 에러 발생 시 원본 반환
+  }
+};
+
+/**
+ * ISO 8601 날짜 문자열을 yyyy.mm.dd HH:mm 형식으로 변환
+ * @param dateString - ISO 8601 형식의 날짜 문자열
+ * @returns yyyy.mm.dd HH:mm 형식의 문자열 (예: "2025.07.22 16:42")
+ */
+export const formatDateTime = (dateString: string): string => {
+  try {
+    const date = new Date(dateString);
+
+    if (isNaN(date.getTime())) {
+      return dateString;
+    }
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+
+    return `${year}.${month}.${day} ${hours}:${minutes}`;
+  } catch {
+    return dateString;
+  }
+};

--- a/apps/web/utils/date/index.ts
+++ b/apps/web/utils/date/index.ts
@@ -1,1 +1,2 @@
 export { formatRelativeTime } from './formatRelativeTime';
+export * from './formatDate';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #212

## 📋 작업 내용

사용자가 자신이 입찰한 상품들의 내역을 조회할 수 있는 구매내역(입찰내역) 페이지를 구현했습니다.
현재 시스템에서는 입찰 성공 시 상품이 바로 SOLD 상태로 변경되어 구매가 완료되므로, 입찰내역 = 구매내역으로 볼 수 있습니다.

### 주요 기능
- 사용자별 입찰 내역 조회 및 표시
- 입찰 시간, 입찰 가격 등 상세 정보 제공
- 상품명 기반 검색 필터링
- 날짜별 필터링 (전체, 최근 7일, 최근 30일, 최근 90일)
- 상품 상세 페이지로의 네비게이션
- 빈 상태 및 검색 결과 없음 처리

## 🔧 변경 사항

- [x] 🎯 입찰 관련 타입 정의 및 유틸리티 추가
- [x] 🔌 입찰 내역 조회 API 및 서비스 구현
- [x] 🪝 입찰 내역 조회 hook 구현
- [x] 🖼️ 입찰 내역 페이지 및 컴포넌트 구현
- [x] 🛠️ 날짜 포맷팅 유틸리티 추가
- [x] 🔧 라우팅 및 기존 코드 통합 업데이트

### 주요 변경 사항 요약:

**Backend:**
- `GET /api/bids/my` - 사용자별 입찰 내역 조회 API
- `getBidHistory` - 입찰 내역 조회 서비스 함수
- 입찰 데이터와 관련 상품 정보를 포함한 응답 구조

**Frontend:**
- `/mypage/bids` - 구매내역(입찰내역) 페이지
- `BidHistoryContainer` - 메인 컨테이너 컴포넌트
- `BidHistoryCard` - 개별 입찰 카드 컴포넌트
- `BidHistoryFilter` - 날짜 및 검색 필터 컴포넌트
- `useBidHistory` - 입찰 내역 조회 hook

**Types & Utils:**
- `BidHistory`, `BidHistoryResponse` 등 입찰 관련 타입 정의
- `formatDate`, `formatDateTime` - 날짜 포맷팅 유틸리티
- `mapBidHistoryResponse` - API 응답 매핑 유틸리티

**UI/UX:**
- 마이페이지 메뉴에서 "구매내역" → "낙찰내역"으로 명칭 변경
- 일관된 디자인 시스템 적용
- 모바일 최적화된 반응형 UI
- 로딩 상태 및 에러 처리

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/e8c26d05-4529-4c14-8bb5-c2d8dd209cc3



## 📄 기타

