### PR TITLE
[fix] Avatar 컴포넌트의 대체 이미지 오류 및 최적화 #231

### DIFF
--- a/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
+++ b/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
@@ -89,7 +89,7 @@ const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
           // 기본 스타일
           'relative inline-flex shrink-0 overflow-hidden rounded-full',
           // 보더 및 배경 스타일 (디자인 시스템 컬러 사용)
-          'border border-border-base bg-bg-base',
+          'border border-border-base bg-[var(--color-border-base)]',
           // 크기
           sizeConfig.container,
           // 호버 효과 (상호작용 개선)

--- a/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
+++ b/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
@@ -1,15 +1,13 @@
 'use client';
 
 import { forwardRef } from 'react';
-import Image from 'next/image';
+
 import { cn } from '@ui/utils/cn';
 
 export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   src?: string; // 프로필 이미지 URL
   alt: string;
   size?: 'sm' | 'md' | 'lg' | 'xl'; // 아바타 크기
-  name?: string;
-  priority?: boolean; // 이미지 로딩 우선순위
   onImageError?: () => void; // 이미지 로드 실패 시 콜백
 }
 
@@ -34,24 +32,17 @@ const AVATAR_SIZES = {
 } as const;
 
 const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
-  ({ src, alt, size = 'md', name, priority = false, onImageError, className, ...props }, ref) => {
-    // Fallback 아바타 생성 함수
-    const generateFallbackAvatar = (seedName: string) => {
-      return `https://api.dicebear.com/7.x/thumbs/svg?seed=${encodeURIComponent(seedName)}`;
-    };
-
-    // 이미지 소스 결정
-    const imageSrc = src || generateFallbackAvatar(name || alt);
+  ({ src, alt, size = 'md', onImageError, className, ...props }, ref) => {
     const sizeConfig = AVATAR_SIZES[size];
 
     return (
-      <div
+      <figure
         ref={ref}
         className={cn(
           // 기본 스타일
           'relative inline-flex shrink-0 overflow-hidden rounded-full',
-          // 보더 스타일 (디자인 시스템 컬러 사용)
-          'border border-border-base',
+          // 보더 및 배경 스타일 (디자인 시스템 컬러 사용)
+          'border border-border-base bg-bg-base',
           // 크기
           sizeConfig.container,
           // 호버 효과 (상호작용 개선)
@@ -60,19 +51,41 @@ const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
         )}
         {...props}
       >
-        <Image
-          src={imageSrc}
-          alt={alt}
-          width={sizeConfig.pixels}
-          height={sizeConfig.pixels}
-          priority={priority}
-          className="object-cover size-full"
-          onError={onImageError}
-          // 이미지 최적화 설정
-          sizes={`${sizeConfig.pixels}px`}
-          quality={85}
-        />
-      </div>
+        {src ? (
+          <img
+            src={src}
+            alt={alt}
+            width={sizeConfig.pixels}
+            height={sizeConfig.pixels}
+            className="object-cover size-full"
+            onError={onImageError}
+            sizes={`${sizeConfig.pixels}px`}
+          />
+        ) : (
+          <svg
+            width="100%"
+            height="100%"
+            viewBox="0 0 122 121"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g clipPath="url(#clip0_98_11527)">
+              <ellipse cx="61" cy="60.5" rx="61" ry="60.5" fill="#DAE3EA" />
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M72.6189 48.9762C72.6189 55.3431 67.4193 60.5 60.9998 60.5C54.5803 60.5 49.3808 55.3431 49.3808 48.9762C49.3808 42.6093 54.5803 37.4524 60.9998 37.4524C67.4193 37.4524 72.6189 42.6093 72.6189 48.9762ZM37.7617 77.7857C37.7617 70.1224 53.2441 66.2619 60.9998 66.2619C68.7555 66.2619 84.2379 70.1224 84.2379 77.7857V80.6667C84.2379 82.2512 82.9308 83.5476 81.3331 83.5476H40.6665C39.0689 83.5476 37.7617 82.2512 37.7617 80.6667V77.7857Z"
+                fill="#94A3B1"
+              />
+            </g>
+            <defs>
+              <clipPath id="clip0_98_11527">
+                <rect width="122" height="121" fill="white" />
+              </clipPath>
+            </defs>
+          </svg>
+        )}
+      </figure>
     );
   }
 );

--- a/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
+++ b/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
@@ -31,6 +31,32 @@ const AVATAR_SIZES = {
   },
 } as const;
 
+// 기본 프로필 이미지 SVG
+const defaultProfileImg = (
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="0 0 122 121"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g clipPath="url(#clip0_98_11527)">
+      <ellipse cx="61" cy="60.5" rx="61" ry="60.5" fill="#DAE3EA" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M72.6189 48.9762C72.6189 55.3431 67.4193 60.5 60.9998 60.5C54.5803 60.5 49.3808 55.3431 49.3808 48.9762C49.3808 42.6093 54.5803 37.4524 60.9998 37.4524C67.4193 37.4524 72.6189 42.6093 72.6189 48.9762ZM37.7617 77.7857C37.7617 70.1224 53.2441 66.2619 60.9998 66.2619C68.7555 66.2619 84.2379 70.1224 84.2379 77.7857V80.6667C84.2379 82.2512 82.9308 83.5476 81.3331 83.5476H40.6665C39.0689 83.5476 37.7617 82.2512 37.7617 80.6667V77.7857Z"
+        fill="#94A3B1"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_98_11527">
+        <rect width="122" height="121" fill="white" />
+      </clipPath>
+    </defs>
+  </svg>
+);
+
 const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
   ({ src, alt, size = 'md', onImageError, className, ...props }, ref) => {
     const [hasImageError, setHasImageError] = useState(false);
@@ -83,28 +109,7 @@ const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
             sizes={`${sizeConfig.pixels}px`}
           />
         ) : (
-          <svg
-            width="100%"
-            height="100%"
-            viewBox="0 0 122 121"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <g clipPath="url(#clip0_98_11527)">
-              <ellipse cx="61" cy="60.5" rx="61" ry="60.5" fill="#DAE3EA" />
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M72.6189 48.9762C72.6189 55.3431 67.4193 60.5 60.9998 60.5C54.5803 60.5 49.3808 55.3431 49.3808 48.9762C49.3808 42.6093 54.5803 37.4524 60.9998 37.4524C67.4193 37.4524 72.6189 42.6093 72.6189 48.9762ZM37.7617 77.7857C37.7617 70.1224 53.2441 66.2619 60.9998 66.2619C68.7555 66.2619 84.2379 70.1224 84.2379 77.7857V80.6667C84.2379 82.2512 82.9308 83.5476 81.3331 83.5476H40.6665C39.0689 83.5476 37.7617 82.2512 37.7617 80.6667V77.7857Z"
-                fill="#94A3B1"
-              />
-            </g>
-            <defs>
-              <clipPath id="clip0_98_11527">
-                <rect width="122" height="121" fill="white" />
-              </clipPath>
-            </defs>
-          </svg>
+          defaultProfileImg
         )}
       </figure>
     );

--- a/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
+++ b/packages/ui/src/design-system/base-components/Avatar/Avatar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 
 import { cn } from '@ui/utils/cn';
 
@@ -33,7 +33,28 @@ const AVATAR_SIZES = {
 
 const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
   ({ src, alt, size = 'md', onImageError, className, ...props }, ref) => {
+    const [hasImageError, setHasImageError] = useState(false);
     const sizeConfig = AVATAR_SIZES[size];
+
+    // 이미지 로딩 실패 처리
+    const handleImageError = () => {
+      // 개발 환경에서 디버깅을 위한 콘솔 로그
+      if (process.env.NODE_ENV === 'development') {
+        console.error(`[Avatar] 이미지 로딩 실패:`, {
+          src,
+          alt,
+          size,
+          timestamp: new Date().toISOString(),
+          userAgent: navigator.userAgent,
+        });
+      }
+
+      // 내부 상태 업데이트 - 디폴트 이미지로 자동 전환
+      setHasImageError(true);
+
+      // 외부 콜백 실행 (사용자 정의 에러 처리)
+      onImageError?.();
+    };
 
     return (
       <figure
@@ -51,14 +72,14 @@ const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
         )}
         {...props}
       >
-        {src ? (
+        {src && !hasImageError ? (
           <img
             src={src}
             alt={alt}
             width={sizeConfig.pixels}
             height={sizeConfig.pixels}
             className="object-cover size-full"
-            onError={onImageError}
+            onError={handleImageError}
             sizes={`${sizeConfig.pixels}px`}
           />
         ) : (


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

fix/default-avatar-ui-component-23

## 📋 작업 내용

**1. Next.js Image 컴포넌트 제거**

  - Before: Next.js Image 컴포넌트 사용으로 무거운 번들 크기
  - After: 일반 <img> 태그로 대체하여 경량화

  **2. 이미지 로딩 실패 시 자동 처리**

  - 기능: 이미지 로딩 실패 시 자동으로 기본 SVG 아바타로 전환
  - 개발자 도구: 개발 환경에서 상세한 에러 정보 콘솔 출력
  - 사용자 경험: 깨진 이미지 없이 항상 깔끔한 아바타 표시

  **3. 코드 구조 개선**

  - SVG 분리: 긴 SVG 코드를 defaultProfileImg 변수로 분리
  - 가독성 향상: 컴포넌트 로직과 디자인 요소 분리
  - 유지보수성: 기본 아바타 변경 시 한 곳에서만 수정

  **4. UI/UX 개선**

  - 시각적 일관성: 배경색과 보더색상 통일로 깨진 느낌 제거
  - 상태 관리: useState로 이미지 에러 상태 추적
  - 개발자 친화적: 타입 안전성 유지 및 명확한 에러 메시지

  **🔧 기술적 장점**

  - 번들 크기 감소: Next.js Image 제거로 경량화
  - 독립성: 프레임워크 의존성 제거
  - 안정성: 이미지 에러 처리로 견고함 향상
  - 개발 경험: 명확한 디버깅 정보 제공


## 🔧 변경 사항

-  🔨 채팅 화면의 아바타 컴포넌트 사이즈 수정 
-  📦 ui 패키지 아바타 컴포넌트 


## 📸 스크린샷 (선택 사항)

- 프로필 이미지 적용
  <img width="400" height="508" alt="image" src="https://github.com/user-attachments/assets/cdad0fb5-3a8d-4dc0-a358-9ccd2d697bc5" />

- 채팅 화면에서 아바타 이미지 사이즈를 sm에서 md 사이즈로 변경
  <img width="377" height="557" alt="image" src="https://github.com/user-attachments/assets/3e324288-1421-4f90-ad8a-b4d2ce93faa1" />
  <img width="379" height="351" alt="image" src="https://github.com/user-attachments/assets/d644c90e-0bb4-4dca-80cb-e8e6e06b50d1" />



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
