### PR TITLE
[refactor] 리액트 아이콘 번들 최소화 #257

### DIFF
--- a/apps/web/components/search/RecentKeywords.tsx
+++ b/apps/web/components/search/RecentKeywords.tsx
@@ -54,7 +54,7 @@ const RecentKeywords = ({ onKeywordClick, selectedIndex = -1 }: RecentKeywordsPr
                   selectedIndex === index && 'text-text-primary'
                 )}
               >
-                <Icon name="ClockThin" size="xs" color="info" />
+                <Icon name="Clock" size="xs" color="info" />
 
                 <span className="flex-1">{search}</span>
               </button>
@@ -74,7 +74,7 @@ const RecentKeywords = ({ onKeywordClick, selectedIndex = -1 }: RecentKeywordsPr
         </ul>
       ) : (
         <div className="text-center text-text-info py-8">
-          <Icon name="ClockThin" size="lg" color="info" className="mx-auto mb-2" />
+          <Icon name="Clock" size="lg" color="info" className="mx-auto mb-2" />
           <p>최근 검색어가 없습니다.</p>
         </div>
       )}

--- a/packages/ui/src/design-system/base-components/FormMessage/FormMessage.tsx
+++ b/packages/ui/src/design-system/base-components/FormMessage/FormMessage.tsx
@@ -1,4 +1,4 @@
-import { MdCheckCircle, MdInfo } from 'react-icons/md';
+import { Icon } from '@ui/components';
 
 export interface FormMessageProps {
   id?: string;
@@ -18,7 +18,7 @@ export const FormMessage = ({ id, type, children }: FormMessageProps) => {
   if (type === 'success') {
     return (
       <div className="mt-xs flex items-center gap-xs">
-        <MdCheckCircle className="w-4 h-4 text-text-success" />
+        <Icon name="CheckCircleFill" className="w-4 h-4 text-text-success" />
         <span className="font-style-small text-text-success">{children}</span>
       </div>
     );
@@ -27,7 +27,7 @@ export const FormMessage = ({ id, type, children }: FormMessageProps) => {
   if (type === 'helper') {
     return (
       <p id={id} className="mt-xs font-style-small text-text-info flex items-center gap-xs">
-        <MdInfo className="w-4 h-4" />
+        <Icon name="InfoFill" className="w-4 h-4" />
         {children}
       </p>
     );

--- a/packages/ui/src/design-system/base-components/IconButton/IconButton.stories.tsx
+++ b/packages/ui/src/design-system/base-components/IconButton/IconButton.stories.tsx
@@ -1487,9 +1487,7 @@ export const ALLIconStyles: Story = {
       <IconsTable iconName="ArrowRight" ariaLabel="더보기" />
       <IconsTable iconName="ArrowUp" ariaLabel="토글 닫기" />
       <IconsTable iconName="ArrowDown" ariaLabel="토글 열기" />
-      <IconsTable iconName="ClockFill" ariaLabel="시간" />
       <IconsTable iconName="Clock" ariaLabel="시간" />
-      <IconsTable iconName="ClockThin" ariaLabel="시간" />
       <IconsTable iconName="Home" ariaLabel="홈" />
       <IconsTable iconName="HomeFill" ariaLabel="홈" />
       <IconsTable iconName="Refresh" ariaLabel="" />

--- a/packages/ui/src/design-system/base-components/Icons/assets/Icons.ts
+++ b/packages/ui/src/design-system/base-components/Icons/assets/Icons.ts
@@ -13,6 +13,8 @@ import {
   GoX,
   GoXCircle,
   GoShare,
+  GoCheckCircle,
+  GoCheckCircleFill,
 } from 'react-icons/go';
 import {
   IoSend,
@@ -34,6 +36,10 @@ import {
   IoChevronForward,
   IoChevronUp,
   IoChevronDown,
+  IoEye,
+  IoEyeOff,
+  IoInformationCircleOutline,
+  IoInformationCircleSharp,
 } from 'react-icons/io5';
 
 export const ICONS = {
@@ -47,6 +53,15 @@ export const ICONS = {
 
   HeartFill: GoHeartFill,
   Heart: GoHeart,
+
+  IoEyeFill: IoEye,
+  IoEyeOffFill: IoEyeOff,
+
+  Info: IoInformationCircleOutline,
+  InfoFill: IoInformationCircleSharp,
+
+  CheckCircle: GoCheckCircle,
+  CheckCircleFill: GoCheckCircleFill,
 
   WarningFill: IoWarning,
   Warning: IoWarningOutline,

--- a/packages/ui/src/design-system/base-components/Icons/assets/Icons.ts
+++ b/packages/ui/src/design-system/base-components/Icons/assets/Icons.ts
@@ -1,34 +1,46 @@
-import { FaAngleDown, FaAngleLeft, FaAngleRight, FaAngleUp } from 'react-icons/fa6';
-import { GoBellFill, GoBell, GoHeartFill, GoHeart, GoHome, GoHomeFill } from 'react-icons/go';
-import { BsClockFill, BsClock, BsChat, BsChatFill } from 'react-icons/bs';
-import { RxHamburgerMenu } from 'react-icons/rx';
-import { HiOutlineShoppingBag, HiShoppingBag, HiSearch } from 'react-icons/hi';
-import { HiXMark } from 'react-icons/hi2';
-import { CiClock1 } from 'react-icons/ci';
 import {
-  PiMagnifyingGlassBold,
-  PiExport,
-  PiExportFill,
-  PiUser,
-  PiUserFill,
-  PiWarningFill,
-  PiWarningLight,
-} from 'react-icons/pi';
+  GoBellFill,
+  GoBell,
+  GoHeartFill,
+  GoHeart,
+  GoHome,
+  GoHomeFill,
+  GoPackageDependents,
+  GoClock,
+  GoSearch,
+  GoPerson,
+  GoPersonFill,
+  GoX,
+  GoXCircle,
+  GoShare,
+} from 'react-icons/go';
 import {
-  MdRefresh,
-  MdOutlinePhotoCamera,
-  MdOutlineLocationOn,
-  MdMoreVert,
-  MdMyLocation,
-} from 'react-icons/md';
-import { IoSend, IoSettingsOutline, IoSettingsSharp } from 'react-icons/io5';
-import { VscError } from 'react-icons/vsc';
+  IoSend,
+  IoSettingsOutline,
+  IoSettingsSharp,
+  IoWarning,
+  IoWarningOutline,
+  IoChatbubbleOutline,
+  IoChatbubbleSharp,
+  IoBagHandleOutline,
+  IoBagHandle,
+  IoCameraOutline,
+  IoMenuOutline,
+  IoRefresh,
+  IoLocationOutline,
+  IoEllipsisVertical,
+  IoLocate,
+  IoChevronBack,
+  IoChevronForward,
+  IoChevronUp,
+  IoChevronDown,
+} from 'react-icons/io5';
 
 export const ICONS = {
-  ArrowDown: FaAngleDown,
-  ArrowLeft: FaAngleLeft,
-  ArrowRight: FaAngleRight,
-  ArrowUp: FaAngleUp,
+  ArrowDown: IoChevronDown,
+  ArrowLeft: IoChevronBack,
+  ArrowRight: IoChevronForward,
+  ArrowUp: IoChevronUp,
 
   BellFill: GoBellFill,
   Bell: GoBell,
@@ -36,45 +48,41 @@ export const ICONS = {
   HeartFill: GoHeartFill,
   Heart: GoHeart,
 
-  WarningFill: PiWarningFill,
-  Warning: PiWarningLight,
+  WarningFill: IoWarning,
+  Warning: IoWarningOutline,
 
-  Error: VscError,
+  Error: GoXCircle,
 
-  ClockFill: BsClockFill,
-  Clock: BsClock,
-  ClockThin: CiClock1,
+  Clock: GoClock,
 
-  Hamburger: RxHamburgerMenu,
+  Hamburger: IoMenuOutline,
 
-  Refresh: MdRefresh,
-  Photo: MdOutlinePhotoCamera,
-
-  MagnifyingGlass: PiMagnifyingGlassBold,
+  Refresh: IoRefresh,
+  Photo: IoCameraOutline,
 
   Home: GoHome,
   HomeFill: GoHomeFill,
-  Chat: BsChat,
-  ChatFill: BsChatFill,
+  Chat: IoChatbubbleOutline,
+  ChatFill: IoChatbubbleSharp,
   SendFill: IoSend,
 
-  ShoppingBag: HiOutlineShoppingBag,
-  ShoppingBagFill: HiShoppingBag,
+  ShoppingBag: IoBagHandleOutline,
+  ShoppingBagFill: IoBagHandle,
 
-  Export: PiExport,
-  ExportFill: PiExportFill,
+  Export: GoPackageDependents,
+  ExportFill: GoShare,
 
-  User: PiUser,
-  UserFill: PiUserFill,
+  User: GoPerson,
+  UserFill: GoPersonFill,
 
-  Location: MdOutlineLocationOn,
-  CurrentLocation: MdMyLocation,
+  Location: IoLocationOutline,
+  CurrentLocation: IoLocate,
 
-  Search: HiSearch,
+  Search: GoSearch,
 
-  Cancel: HiXMark,
+  Cancel: GoX,
 
-  MoreVert: MdMoreVert,
+  MoreVert: IoEllipsisVertical,
 
   Setting: IoSettingsOutline,
   SettingFill: IoSettingsSharp,

--- a/packages/ui/src/design-system/base-components/Input/components/PasswordToggle.tsx
+++ b/packages/ui/src/design-system/base-components/Input/components/PasswordToggle.tsx
@@ -1,4 +1,4 @@
-import { MdVisibility, MdVisibilityOff } from 'react-icons/md';
+import { Icon } from '@ui/components';
 
 import { cn } from '@ui/utils/cn';
 
@@ -37,9 +37,9 @@ export const PasswordToggle = ({
       aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
     >
       {showPassword ? (
-        <MdVisibilityOff className="w-5 h-5" />
+        <Icon name="IoEyeOffFill" className="w-5 h-5" />
       ) : (
-        <MdVisibility className="w-5 h-5" />
+        <Icon name="IoEyeFill" className="w-5 h-5" />
       )}
     </button>
   );


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- [x] 리액트 아이콘 패밀리 의존성 최소화
- [x] 아이콘 컴포넌트 없이 별도로 아이콘 호출해서 사용하는 부분 개선

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

-  의존하고 있는 리액트 아이콘 패밀리 종류가 다양할수록 리액트 아이콘 번들 사이즈가 커지는 문제가 있어서 최대한 유사한 아이콘을 선택하면서도 의존하는 아이콘 패밀리를 최소화 할 수 있는 방향으로 코드 리팩토링

### [수정 전]

<img width="60%" height="547" alt="스크린샷 2025-08-04 오후 2 49 58" src="https://github.com/user-attachments/assets/c4c786bb-ef40-4f5c-83aa-7496dfa8ebe9" />


### [수정 후]

<img width="30%" height="847" alt="스크린샷 2025-08-04 오후 2 49 19" src="https://github.com/user-attachments/assets/b0310ea8-4ec3-40d3-aa2a-4fb6fd3ad2c2" />


## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

### [수정 전] 아이콘 스크립트 로딩 - 5.78초

<img width="70%" alt="스크린샷 2025-08-04 오후 2 46 08" src="https://github.com/user-attachments/assets/73329320-9f36-4bc5-b0a7-1cab90ae8ae7" />

### [수정 후] 아이콘 스크립트 로딩 - 0.317초 (94.5% 감소)

<img width="70%" alt="스크린샷 2025-08-04 오후 2 05 23" src="https://github.com/user-attachments/assets/d9bdc6ac-e027-4a2f-8af1-02517098d51f" />

### [수정 전] 번들 사이즈 총합 - 14.1MB

<img width="70%" alt="스크린샷 2025-08-04 오전 11 24 27" src="https://github.com/user-attachments/assets/eedc0fad-6b52-45b3-b22c-58d670e5f3e6" />

### [수정 후] 번들 사이즈 총합 - 2.44MB (약  82.7% 감소)

<img width="70%" alt="스크린샷 2025-08-04 오후 3 12 30" src="https://github.com/user-attachments/assets/a62fa66c-57b3-47be-9ff2-c84acdb506ac" />

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
