### PR TITLE
[feat] 경매 상태에 따른 타이머 중지 및 재설정 기능 및 기타 UI 변경  #259

### DIFF
--- a/apps/web/app/(pages)/products/[productId]/(detail)/page.tsx
+++ b/apps/web/app/(pages)/products/[productId]/(detail)/page.tsx
@@ -83,6 +83,7 @@ const ProductDetailPage = async ({ params }: ProductDetailPageParams) => {
     return notFound();
   }
 
+  const isSeller = product.seller_user_id === userId;
   const images = product.product_images.map((image) => image.image_url);
 
   return (
@@ -122,6 +123,7 @@ const ProductDetailPage = async ({ params }: ProductDetailPageParams) => {
         decreaseUnit={product.decrease_unit}
         startedAt={product.auction_started_at}
         status={product.status}
+        isSeller={isSeller}
       />
     </section>
   );

--- a/apps/web/app/(pages)/products/[productId]/(detail)/page.tsx
+++ b/apps/web/app/(pages)/products/[productId]/(detail)/page.tsx
@@ -101,7 +101,7 @@ const ProductDetailPage = async ({ params }: ProductDetailPageParams) => {
           decreaseUnit={product.decrease_unit}
           startPrice={product.start_price}
           minPrice={product.min_price}
-          createdAt={product.created_at}
+          startedAt={product.auction_started_at}
         />
         <div className="flex justify-end mt-md">
           <StatusActionButton
@@ -119,7 +119,7 @@ const ProductDetailPage = async ({ params }: ProductDetailPageParams) => {
         startPrice={product.start_price}
         minPrice={product.min_price}
         decreaseUnit={product.decrease_unit}
-        createdAt={product.created_at}
+        startedAt={product.auction_started_at}
       />
     </section>
   );

--- a/apps/web/app/(pages)/products/[productId]/(detail)/page.tsx
+++ b/apps/web/app/(pages)/products/[productId]/(detail)/page.tsx
@@ -15,6 +15,8 @@ import {
   StatusActionButton,
 } from '@/components/product-detail';
 
+import { getAuthenticatedUser } from '@/utils/auth/server';
+import { getBidByProduct } from '@web/services/bids/server';
 import { getFavoriteStatus } from '@web/services/favorites/server';
 import { fetchProductDetailWithPrisma } from '@web/services/products/server';
 
@@ -59,7 +61,6 @@ export async function generateMetadata({ params }: ProductDetailPageParams): Pro
   };
 }
 
-import { getAuthenticatedUser } from '@/utils/auth/server';
 
 const ProductDetailPage = async ({ params }: ProductDetailPageParams) => {
   const { productId: productIdParam } = await params;
@@ -83,6 +84,11 @@ const ProductDetailPage = async ({ params }: ProductDetailPageParams) => {
     return notFound();
   }
 
+  const finalBidPrice =
+    product.status === 'SOLD'
+      ? (await getBidByProduct(productId))?.bid_price?.toString()
+      : undefined;
+
   const isSeller = product.seller_user_id === userId;
   const images = product.product_images.map((image) => image.image_url);
 
@@ -104,6 +110,7 @@ const ProductDetailPage = async ({ params }: ProductDetailPageParams) => {
           minPrice={product.min_price}
           startedAt={product.auction_started_at}
           status={product.status}
+          finalBidPrice={finalBidPrice}
         />
         <div className="flex justify-end mt-md">
           <StatusActionButton
@@ -124,6 +131,7 @@ const ProductDetailPage = async ({ params }: ProductDetailPageParams) => {
         startedAt={product.auction_started_at}
         status={product.status}
         isSeller={isSeller}
+        finalBidPrice={finalBidPrice}
       />
     </section>
   );

--- a/apps/web/app/(pages)/products/[productId]/(detail)/page.tsx
+++ b/apps/web/app/(pages)/products/[productId]/(detail)/page.tsx
@@ -4,9 +4,6 @@ import { Metadata } from 'next';
 
 import { notFound } from 'next/navigation';
 
-import { getFavoriteStatus } from '@/services/favorites/server';
-import { fetchProductDetailWithPrisma } from '@/services/products/server';
-
 import {
   ProductDetailHeader,
   ProductImageCarousel,
@@ -17,6 +14,9 @@ import {
   UserInfoLayout,
   StatusActionButton,
 } from '@/components/product-detail';
+
+import { getFavoriteStatus } from '@web/services/favorites/server';
+import { fetchProductDetailWithPrisma } from '@web/services/products/server';
 
 interface ProductDetailPageParams {
   params: Promise<{ productId: string }>;

--- a/apps/web/app/(pages)/products/[productId]/(detail)/page.tsx
+++ b/apps/web/app/(pages)/products/[productId]/(detail)/page.tsx
@@ -102,6 +102,7 @@ const ProductDetailPage = async ({ params }: ProductDetailPageParams) => {
           startPrice={product.start_price}
           minPrice={product.min_price}
           startedAt={product.auction_started_at}
+          status={product.status}
         />
         <div className="flex justify-end mt-md">
           <StatusActionButton
@@ -120,6 +121,7 @@ const ProductDetailPage = async ({ params }: ProductDetailPageParams) => {
         minPrice={product.min_price}
         decreaseUnit={product.decrease_unit}
         startedAt={product.auction_started_at}
+        status={product.status}
       />
     </section>
   );

--- a/apps/web/app/api/bids/route.ts
+++ b/apps/web/app/api/bids/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
       product.start_price.toNumber(),
       product.min_price.toNumber(),
       product.decrease_unit.toNumber(),
-      product.created_at.toISOString()
+      product.auction_started_at.toISOString()
     );
 
     if (calculatedCurrentPrice.toFixed(2) !== bidPrice.toFixed(2)) {

--- a/apps/web/app/api/products/route.ts
+++ b/apps/web/app/api/products/route.ts
@@ -34,6 +34,7 @@ export async function POST(request: NextRequest) {
           seller_user_id: authResult.userId!,
           created_at: new Date(),
           updated_at: new Date(),
+          auction_started_at: new Date(),
         },
       });
 

--- a/apps/web/components/product-detail/AuctionInfoLayout.tsx
+++ b/apps/web/components/product-detail/AuctionInfoLayout.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useCurrentPrice } from '@/hooks/products';
-
-import { Timer } from '../shared';
+import { Timer } from '@web/components/shared';
+import { useCurrentPrice } from '@web/hooks/products';
 
 import AuctionSummary from './AuctionSummary';
 import CurrentPrice from './CurrentPrice';

--- a/apps/web/components/product-detail/AuctionInfoLayout.tsx
+++ b/apps/web/components/product-detail/AuctionInfoLayout.tsx
@@ -28,6 +28,7 @@ const AuctionInfoLayout = ({
     minPrice,
     decreaseUnit,
     auctionStartedAt: startedAt,
+    status,
   });
 
   return (
@@ -40,6 +41,7 @@ const AuctionInfoLayout = ({
             minPrice={minPrice}
             decreaseUnit={decreaseUnit}
             auctionStartedAt={startedAt}
+            status={status}
           />
         </div>
         <div className="flex flex-col items-center flex-1 gap-y-0.5">
@@ -58,6 +60,7 @@ const AuctionInfoLayout = ({
             minPrice={minPrice}
             decreaseUnit={decreaseUnit}
             auctionStartedAt={startedAt}
+            status={status}
           />
         </div>
       </div>

--- a/apps/web/components/product-detail/AuctionInfoLayout.tsx
+++ b/apps/web/components/product-detail/AuctionInfoLayout.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { Timer } from '@web/components/shared';
+import { PRODUCT_STATUS } from '@web/constants';
 import { useCurrentPrice } from '@web/hooks/products';
+
+import { ProductStatus } from '@web/types';
 
 import AuctionSummary from './AuctionSummary';
 import CurrentPrice from './CurrentPrice';
@@ -12,7 +15,7 @@ interface AuctionInfoLayoutProps {
   startPrice: number;
   minPrice: number;
   startedAt: string;
-  status: 'ACTIVE' | 'SOLD' | 'CANCEL';
+  status: ProductStatus;
 }
 
 const AuctionInfoLayout = ({
@@ -45,14 +48,24 @@ const AuctionInfoLayout = ({
         </div>
         <div className="flex flex-col items-center flex-1 gap-y-0.5">
           <div className="flex items-center gap-x-1">
-            <Timer
-              startTime={startedAt}
-              currentPrice={currentPrice}
-              minPrice={minPrice}
-              status={status}
-              className="text-xs text-text-primary font-bold"
-            />
-            <span className="text-xs text-text-info font-bold">뒤 인하</span>
+            {status === PRODUCT_STATUS.SOLD ? (
+              <span className="text-xs text-text-error font-bold">경매 종료</span>
+            ) : status === PRODUCT_STATUS.CANCEL ? (
+              <span className="text-xs text-text-info font-bold">경매 중지</span>
+            ) : currentPrice === minPrice ? (
+              <span className="text-xs text-text-primary font-bold">하한가 도달</span>
+            ) : (
+              <>
+                <Timer
+                  startTime={startedAt}
+                  currentPrice={currentPrice}
+                  minPrice={minPrice}
+                  status={status}
+                  className="text-xs text-text-primary font-bold"
+                />
+                <span className="text-xs text-text-info font-bold">뒤 인하</span>
+              </>
+            )}
           </div>
           <NextPrice
             startPrice={startPrice}

--- a/apps/web/components/product-detail/AuctionInfoLayout.tsx
+++ b/apps/web/components/product-detail/AuctionInfoLayout.tsx
@@ -13,6 +13,7 @@ interface AuctionInfoLayoutProps {
   startPrice: number;
   minPrice: number;
   startedAt: string;
+  status: 'ACTIVE' | 'SOLD' | 'CANCEL';
 }
 
 const AuctionInfoLayout = ({
@@ -20,6 +21,7 @@ const AuctionInfoLayout = ({
   startPrice,
   minPrice,
   startedAt,
+  status,
 }: AuctionInfoLayoutProps) => {
   const currentPrice = useCurrentPrice({
     startPrice,
@@ -46,6 +48,7 @@ const AuctionInfoLayout = ({
               startTime={startedAt}
               currentPrice={currentPrice}
               minPrice={minPrice}
+              status={status}
               className="text-xs text-text-primary font-bold"
             />
             <span className="text-xs text-text-info font-bold">뒤 인하</span>

--- a/apps/web/components/product-detail/AuctionInfoLayout.tsx
+++ b/apps/web/components/product-detail/AuctionInfoLayout.tsx
@@ -12,20 +12,20 @@ interface AuctionInfoLayoutProps {
   decreaseUnit: number;
   startPrice: number;
   minPrice: number;
-  createdAt: string;
+  startedAt: string;
 }
 
 const AuctionInfoLayout = ({
   decreaseUnit,
   startPrice,
   minPrice,
-  createdAt,
+  startedAt,
 }: AuctionInfoLayoutProps) => {
   const currentPrice = useCurrentPrice({
     startPrice,
     minPrice,
     decreaseUnit,
-    auctionStartedAt: createdAt,
+    auctionStartedAt: startedAt,
   });
 
   return (
@@ -37,13 +37,13 @@ const AuctionInfoLayout = ({
             startPrice={startPrice}
             minPrice={minPrice}
             decreaseUnit={decreaseUnit}
-            auctionStartedAt={createdAt}
+            auctionStartedAt={startedAt}
           />
         </div>
         <div className="flex flex-col items-center flex-1 gap-y-0.5">
           <div className="flex items-center gap-x-1">
             <Timer
-              startTime={createdAt}
+              startTime={startedAt}
               currentPrice={currentPrice}
               minPrice={minPrice}
               className="text-xs text-text-primary font-bold"
@@ -54,7 +54,7 @@ const AuctionInfoLayout = ({
             startPrice={startPrice}
             minPrice={minPrice}
             decreaseUnit={decreaseUnit}
-            auctionStartedAt={createdAt}
+            auctionStartedAt={startedAt}
           />
         </div>
       </div>

--- a/apps/web/components/product-detail/AuctionInfoLayout.tsx
+++ b/apps/web/components/product-detail/AuctionInfoLayout.tsx
@@ -16,6 +16,7 @@ interface AuctionInfoLayoutProps {
   minPrice: number;
   startedAt: string;
   status: ProductStatus;
+  finalBidPrice?: string;
 }
 
 const AuctionInfoLayout = ({
@@ -24,6 +25,7 @@ const AuctionInfoLayout = ({
   minPrice,
   startedAt,
   status,
+  finalBidPrice,
 }: AuctionInfoLayoutProps) => {
   const currentPrice = useCurrentPrice({
     startPrice,
@@ -44,6 +46,7 @@ const AuctionInfoLayout = ({
             decreaseUnit={decreaseUnit}
             auctionStartedAt={startedAt}
             status={status}
+            finalBidPrice={finalBidPrice}
           />
         </div>
         <div className="flex flex-col items-center flex-1 gap-y-0.5">

--- a/apps/web/components/product-detail/BidButton.tsx
+++ b/apps/web/components/product-detail/BidButton.tsx
@@ -8,9 +8,11 @@ import { API_ROUTES } from '@web/constants/routes';
 interface BidButtonProps {
   productId: number;
   currentPrice: number;
+  status: 'ACTIVE' | 'SOLD' | 'CANCEL';
+  isSeller: boolean;
 }
 
-const BidButton = ({ productId, currentPrice }: BidButtonProps) => {
+const BidButton = ({ productId, currentPrice, status, isSeller }: BidButtonProps) => {
   const handleBid = async () => {
     const isConfirmed = confirm(`${currentPrice.toLocaleString()}원에 입찰하시겠습니까?`);
 
@@ -50,7 +52,12 @@ const BidButton = ({ productId, currentPrice }: BidButtonProps) => {
   };
 
   return (
-    <Button onClick={handleBid} isFullWidth={false} size="lg">
+    <Button
+      onClick={handleBid}
+      isFullWidth={false}
+      size="lg"
+      isDisabled={status !== 'ACTIVE' || isSeller}
+    >
       입찰하기
     </Button>
   );

--- a/apps/web/components/product-detail/BidButton.tsx
+++ b/apps/web/components/product-detail/BidButton.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import { Button } from '@repo/ui/components';
-import { toast } from '@repo/ui/utils';
+import { Button, toast } from '@repo/ui/components';
 
+import { PRODUCT_STATUS } from '@web/constants';
 import { API_ROUTES } from '@web/constants/routes';
+import type { ProductStatus } from '@web/types';
 
 interface BidButtonProps {
   productId: number;
   currentPrice: number;
-  status: 'ACTIVE' | 'SOLD' | 'CANCEL';
+  status: ProductStatus;
   isSeller: boolean;
 }
 
@@ -56,7 +57,7 @@ const BidButton = ({ productId, currentPrice, status, isSeller }: BidButtonProps
       onClick={handleBid}
       isFullWidth={false}
       size="lg"
-      isDisabled={status !== 'ACTIVE' || isSeller}
+      isDisabled={status !== PRODUCT_STATUS.ACTIVE || isSeller}
     >
       입찰하기
     </Button>

--- a/apps/web/components/product-detail/CurrentPrice.tsx
+++ b/apps/web/components/product-detail/CurrentPrice.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { PRODUCT_STATUS } from '@/constants';
-import { useCurrentPrice } from '@/hooks/products';
-import type { ProductStatus } from '@/types';
+import { useCurrentPrice } from '@web/hooks/products';
+import type { ProductStatus } from '@web/types';
 
 interface CurrentPriceProps {
   startPrice: number;

--- a/apps/web/components/product-detail/CurrentPrice.tsx
+++ b/apps/web/components/product-detail/CurrentPrice.tsx
@@ -1,12 +1,15 @@
 'use client';
 
+import { PRODUCT_STATUS } from '@/constants';
 import { useCurrentPrice } from '@/hooks/products';
+import type { ProductStatus } from '@/types';
 
 interface CurrentPriceProps {
   startPrice: number;
   minPrice: number;
   decreaseUnit: number;
   auctionStartedAt: string;
+  status: ProductStatus;
 }
 
 const CurrentPrice = ({
@@ -14,12 +17,14 @@ const CurrentPrice = ({
   minPrice,
   decreaseUnit,
   auctionStartedAt,
+  status,
 }: CurrentPriceProps) => {
   const price = useCurrentPrice({
     startPrice,
     minPrice,
     decreaseUnit,
     auctionStartedAt,
+    status,
   });
 
   return (

--- a/apps/web/components/product-detail/CurrentPrice.tsx
+++ b/apps/web/components/product-detail/CurrentPrice.tsx
@@ -9,6 +9,7 @@ interface CurrentPriceProps {
   decreaseUnit: number;
   auctionStartedAt: string;
   status: ProductStatus;
+  finalBidPrice?: string;
 }
 
 const CurrentPrice = ({
@@ -17,18 +18,22 @@ const CurrentPrice = ({
   decreaseUnit,
   auctionStartedAt,
   status,
+  finalBidPrice,
 }: CurrentPriceProps) => {
-  const price = useCurrentPrice({
-    startPrice,
-    minPrice,
-    decreaseUnit,
-    auctionStartedAt,
-    status,
-  });
+  const displayPrice =
+    finalBidPrice !== undefined
+      ? parseInt(finalBidPrice)
+      : useCurrentPrice({
+          startPrice,
+          minPrice,
+          decreaseUnit,
+          auctionStartedAt,
+          status,
+        });
 
   return (
     <div className="flex flex-col items-center justify-center py-2 px-4 rounded-lg min-w-[140px] bg-[var(--color-orange-50)]">
-      <span className="text-lg font-bold text-text-primary">{price.toLocaleString()}원</span>
+      <span className="text-lg font-bold text-text-primary">{displayPrice.toLocaleString()}원</span>
     </div>
   );
 };

--- a/apps/web/components/product-detail/LikeButton.tsx
+++ b/apps/web/components/product-detail/LikeButton.tsx
@@ -6,7 +6,7 @@ import { IconButton } from '@repo/ui/components';
 import { toast } from '@repo/ui/utils';
 import { useParams } from 'next/navigation';
 
-import { createFavorite, deleteFavorite } from '@/services/favorites/client';
+import { createFavorite, deleteFavorite } from '@web/services/favorites/client';
 
 interface LikeButtonProps {
   initialIsLiked: boolean;

--- a/apps/web/components/product-detail/NextPrice.tsx
+++ b/apps/web/components/product-detail/NextPrice.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { PRODUCT_STATUS } from '@/constants';
-import { useCurrentPrice } from '@/hooks/products';
-import type { ProductStatus } from '@/types';
+import { PRODUCT_STATUS } from '@web/constants';
+import { useCurrentPrice } from '@web/hooks/products';
+import type { ProductStatus } from '@web/types';
 
 interface NextPriceProps {
   startPrice: number;

--- a/apps/web/components/product-detail/NextPrice.tsx
+++ b/apps/web/components/product-detail/NextPrice.tsx
@@ -1,30 +1,40 @@
 'use client';
 
+import { PRODUCT_STATUS } from '@/constants';
 import { useCurrentPrice } from '@/hooks/products';
+import type { ProductStatus } from '@/types';
 
 interface NextPriceProps {
   startPrice: number;
   minPrice: number;
   decreaseUnit: number;
   auctionStartedAt: string;
+  status: ProductStatus;
 }
 
-const NextPrice = ({ startPrice, minPrice, decreaseUnit, auctionStartedAt }: NextPriceProps) => {
+const NextPrice = ({
+  startPrice,
+  minPrice,
+  decreaseUnit,
+  auctionStartedAt,
+  status,
+}: NextPriceProps) => {
   const currentPrice = useCurrentPrice({
     startPrice,
     minPrice,
     decreaseUnit,
     auctionStartedAt,
+    status,
   });
 
   const calculatedNextPrice = currentPrice - decreaseUnit;
   const displayPrice = Math.max(calculatedNextPrice, minPrice);
 
+  const priceText = status === PRODUCT_STATUS.ACTIVE ? `${displayPrice.toLocaleString()}원` : '-';
+
   return (
     <div className="flex flex-col items-center justify-center py-2 px-4 rounded-lg bg-[var(--color-neutral-20)] min-w-[140px]">
-      <span className="text-lg font-bold text-[var(--color-neutral-80)]">
-        {displayPrice.toLocaleString()}원
-      </span>
+      <span className="text-lg font-bold text-[var(--color-neutral-80)]">{priceText}</span>
     </div>
   );
 };

--- a/apps/web/components/product-detail/ProductDetailHeader.tsx
+++ b/apps/web/components/product-detail/ProductDetailHeader.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState } from 'react';
 
-import HeaderContainer from '@/components/layout/header/HeaderContainer';
-import { BackButton } from '@/components/layout/header-icon';
+import HeaderContainer from '@web/components/layout/header/HeaderContainer';
+import { BackButton } from '@web/components/layout/header-icon';
 
 import LikeButton from './LikeButton';
 

--- a/apps/web/components/product-detail/ProductFooter.tsx
+++ b/apps/web/components/product-detail/ProductFooter.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { PRODUCT_STATUS } from '@/constants';
 import { useCurrentPrice } from '@/hooks/products';
+import type { ProductStatus } from '@/types';
 
 import { Timer } from '../shared';
 
@@ -12,7 +14,7 @@ interface ProductFooterProps {
   minPrice: number;
   decreaseUnit: number;
   startedAt: string;
-  status: 'ACTIVE' | 'SOLD' | 'CANCEL';
+  status: ProductStatus;
   isSeller: boolean;
 }
 
@@ -30,6 +32,7 @@ const ProductFooter = ({
     minPrice,
     decreaseUnit,
     auctionStartedAt: startedAt,
+    status,
   });
 
   return (

--- a/apps/web/components/product-detail/ProductFooter.tsx
+++ b/apps/web/components/product-detail/ProductFooter.tsx
@@ -13,6 +13,7 @@ interface ProductFooterProps {
   decreaseUnit: number;
   startedAt: string;
   status: 'ACTIVE' | 'SOLD' | 'CANCEL';
+  isSeller: boolean;
 }
 
 const ProductFooter = ({
@@ -22,6 +23,7 @@ const ProductFooter = ({
   decreaseUnit,
   startedAt,
   status,
+  isSeller,
 }: ProductFooterProps) => {
   const currentPrice = useCurrentPrice({
     startPrice,
@@ -45,7 +47,12 @@ const ProductFooter = ({
           />
         </div>
       </div>
-      <BidButton productId={productId} currentPrice={currentPrice} />
+      <BidButton
+        productId={productId}
+        currentPrice={currentPrice}
+        status={status}
+        isSeller={isSeller}
+      />
     </div>
   );
 };

--- a/apps/web/components/product-detail/ProductFooter.tsx
+++ b/apps/web/components/product-detail/ProductFooter.tsx
@@ -11,7 +11,7 @@ interface ProductFooterProps {
   startPrice: number;
   minPrice: number;
   decreaseUnit: number;
-  createdAt: string;
+  startedAt: string;
 }
 
 const ProductFooter = ({
@@ -19,13 +19,13 @@ const ProductFooter = ({
   startPrice,
   minPrice,
   decreaseUnit,
-  createdAt,
+  startedAt,
 }: ProductFooterProps) => {
   const currentPrice = useCurrentPrice({
     startPrice,
     minPrice,
     decreaseUnit,
-    auctionStartedAt: createdAt,
+    auctionStartedAt: startedAt,
   });
 
   return (
@@ -35,7 +35,7 @@ const ProductFooter = ({
         <div className="flex items-center gap-x-1 text-xs text-text-info mt-1">
           <span>가격 인하까지</span>
           <Timer
-            startTime={createdAt}
+            startTime={startedAt}
             currentPrice={currentPrice}
             minPrice={minPrice}
             className="text-xs text-text-primary"

--- a/apps/web/components/product-detail/ProductFooter.tsx
+++ b/apps/web/components/product-detail/ProductFooter.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import type { ProductStatus } from '@/types';
-
 import { Timer } from '@web/components/shared';
+import { PRODUCT_STATUS } from '@web/constants';
+
 import { useCurrentPrice } from '@web/hooks/products';
+import type { ProductStatus } from '@web/types';
 
 import BidButton from './BidButton';
 
@@ -39,14 +40,24 @@ const ProductFooter = ({
       <div className="flex flex-col">
         <span className="text-xl font-bold text-gray-900">{currentPrice.toLocaleString()}원</span>
         <div className="flex items-center gap-x-1 text-xs text-text-info mt-1">
-          <span>가격 인하까지</span>
-          <Timer
-            startTime={startedAt}
-            currentPrice={currentPrice}
-            minPrice={minPrice}
-            status={status}
-            className="text-xs text-text-primary"
-          />
+          {status === PRODUCT_STATUS.SOLD ? (
+            <span className="text-xs text-text-error font-bold">경매가 종료되었습니다.</span>
+          ) : status === PRODUCT_STATUS.CANCEL ? (
+            <span className="text-xs text-text-info font-bold">경매가 중지되었습니다.</span>
+          ) : currentPrice === minPrice ? (
+            <span className="text-xs text-text-primary font-bold">하한가에 도달했습니다.</span>
+          ) : (
+            <>
+              <span>가격 인하까지</span>
+              <Timer
+                startTime={startedAt}
+                currentPrice={currentPrice}
+                minPrice={minPrice}
+                status={status}
+                className="text-xs text-text-primary"
+              />
+            </>
+          )}
         </div>
       </div>
       <BidButton

--- a/apps/web/components/product-detail/ProductFooter.tsx
+++ b/apps/web/components/product-detail/ProductFooter.tsx
@@ -12,6 +12,7 @@ interface ProductFooterProps {
   minPrice: number;
   decreaseUnit: number;
   startedAt: string;
+  status: 'ACTIVE' | 'SOLD' | 'CANCEL';
 }
 
 const ProductFooter = ({
@@ -20,6 +21,7 @@ const ProductFooter = ({
   minPrice,
   decreaseUnit,
   startedAt,
+  status,
 }: ProductFooterProps) => {
   const currentPrice = useCurrentPrice({
     startPrice,
@@ -38,6 +40,7 @@ const ProductFooter = ({
             startTime={startedAt}
             currentPrice={currentPrice}
             minPrice={minPrice}
+            status={status}
             className="text-xs text-text-primary"
           />
         </div>

--- a/apps/web/components/product-detail/ProductFooter.tsx
+++ b/apps/web/components/product-detail/ProductFooter.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { PRODUCT_STATUS } from '@/constants';
-import { useCurrentPrice } from '@/hooks/products';
 import type { ProductStatus } from '@/types';
 
-import { Timer } from '../shared';
+import { Timer } from '@web/components/shared';
+import { useCurrentPrice } from '@web/hooks/products';
 
 import BidButton from './BidButton';
 

--- a/apps/web/components/product-detail/ProductFooter.tsx
+++ b/apps/web/components/product-detail/ProductFooter.tsx
@@ -16,6 +16,7 @@ interface ProductFooterProps {
   startedAt: string;
   status: ProductStatus;
   isSeller: boolean;
+  finalBidPrice?: string;
 }
 
 const ProductFooter = ({
@@ -26,32 +27,36 @@ const ProductFooter = ({
   startedAt,
   status,
   isSeller,
+  finalBidPrice,
 }: ProductFooterProps) => {
-  const currentPrice = useCurrentPrice({
-    startPrice,
-    minPrice,
-    decreaseUnit,
-    auctionStartedAt: startedAt,
-    status,
-  });
+  const displayPrice =
+    finalBidPrice !== undefined
+      ? parseInt(finalBidPrice)
+      : useCurrentPrice({
+          startPrice,
+          minPrice,
+          decreaseUnit,
+          auctionStartedAt: startedAt,
+          status,
+        });
 
   return (
     <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full md:max-w-container bg-white p-4 border-t border-gray-200 flex justify-between items-center">
       <div className="flex flex-col">
-        <span className="text-xl font-bold text-gray-900">{currentPrice.toLocaleString()}원</span>
+        <span className="text-xl font-bold text-gray-900">{displayPrice.toLocaleString()}원</span>
         <div className="flex items-center gap-x-1 text-xs text-text-info mt-1">
           {status === PRODUCT_STATUS.SOLD ? (
             <span className="text-xs text-text-error font-bold">경매가 종료되었습니다.</span>
           ) : status === PRODUCT_STATUS.CANCEL ? (
             <span className="text-xs text-text-info font-bold">경매가 중지되었습니다.</span>
-          ) : currentPrice === minPrice ? (
+          ) : displayPrice === minPrice ? (
             <span className="text-xs text-text-primary font-bold">하한가에 도달했습니다.</span>
           ) : (
             <>
               <span>가격 인하까지</span>
               <Timer
                 startTime={startedAt}
-                currentPrice={currentPrice}
+                currentPrice={displayPrice}
                 minPrice={minPrice}
                 status={status}
                 className="text-xs text-text-primary"
@@ -62,7 +67,7 @@ const ProductFooter = ({
       </div>
       <BidButton
         productId={productId}
-        currentPrice={currentPrice}
+        currentPrice={displayPrice}
         status={status}
         isSeller={isSeller}
       />

--- a/apps/web/components/product-detail/UserInfoLayout.tsx
+++ b/apps/web/components/product-detail/UserInfoLayout.tsx
@@ -1,4 +1,4 @@
-import { getUserInfo } from '@/services/users/server';
+import { getUserInfo } from '@web/services/users/server';
 
 import ChatButton from './ChatButton';
 import SellerAvatar from './SellerAvatar';

--- a/apps/web/components/products/ProductCard.tsx
+++ b/apps/web/components/products/ProductCard.tsx
@@ -43,6 +43,7 @@ const ProductCard = ({
     minPrice,
     decreaseUnit,
     auctionStartedAt,
+    status,
   });
 
   return (

--- a/apps/web/components/products/ProductCard.tsx
+++ b/apps/web/components/products/ProductCard.tsx
@@ -2,6 +2,8 @@
 
 import Link from 'next/link';
 
+import { PRODUCT_STATUS } from '@/constants/products/product-status';
+
 import { PAGE_ROUTES } from '@/constants';
 import { useCurrentPrice } from '@/hooks/products';
 import type { ProductStatus } from '@/types';
@@ -62,7 +64,11 @@ const ProductCard = ({
 
         <section className="flex flex-col gap-sm">
           <h3 className="font-normal text-base line-clamp-2">{title}</h3>
-          <p className="font-style-large">현재가 {currentPrice.toLocaleString()}원</p>
+          {status === PRODUCT_STATUS.SOLD ? (
+            <p className="font-style-medium font-bold text-text-info">경매가 종료되었습니다</p>
+          ) : (
+            <p className="font-style-large">현재가 {currentPrice.toLocaleString()}원</p>
+          )}
           <p className="text-xs flex items-center gap-xs  text-text-info">
             {region}
             <i>•</i>

--- a/apps/web/components/shared/Timer.tsx
+++ b/apps/web/components/shared/Timer.tsx
@@ -6,6 +6,7 @@ interface TimerProps {
   startTime: string;
   currentPrice: number;
   minPrice: number;
+  status: 'ACTIVE' | 'SOLD' | 'CANCEL';
   className?: string;
 }
 
@@ -29,7 +30,7 @@ const TOTAL_DURATION_SECONDS = 1800;
  *   className="text-lg font-bold"
  * />
  */
-const Timer = ({ startTime, currentPrice, minPrice, className }: TimerProps) => {
+const Timer = ({ startTime, currentPrice, minPrice, status, className }: TimerProps) => {
   const [remainingSeconds, setRemainingSeconds] = useState<number>(0);
   const animationFrameRef = useRef<number | null>(null);
 
@@ -37,8 +38,8 @@ const Timer = ({ startTime, currentPrice, minPrice, className }: TimerProps) => 
     const startTimestamp = new Date(startTime).getTime();
 
     const updateTimer = () => {
-      // currentPrice와 minPrice가 같으면 타이머를 비활성화
-      if (currentPrice === minPrice) {
+      // status가 ACTIVE가 아니거나 currentPrice와 minPrice가 같으면 타이머를 비활성화
+      if (status !== 'ACTIVE' || currentPrice === minPrice) {
         setRemainingSeconds(0);
         if (animationFrameRef.current) {
           cancelAnimationFrame(animationFrameRef.current);
@@ -75,7 +76,7 @@ const Timer = ({ startTime, currentPrice, minPrice, className }: TimerProps) => 
         cancelAnimationFrame(animationFrameRef.current);
       }
     };
-  }, [startTime, currentPrice, minPrice]);
+  }, [startTime, currentPrice, minPrice, status]);
 
   const minutes = Math.floor(remainingSeconds / 60);
   const seconds = remainingSeconds % 60;
@@ -83,7 +84,7 @@ const Timer = ({ startTime, currentPrice, minPrice, className }: TimerProps) => 
   const formattedMinutes = String(minutes).padStart(2, '0');
   const formattedSeconds = String(seconds).padStart(2, '0');
 
-  const isDisabled = currentPrice === minPrice;
+  const isDisabled = currentPrice === minPrice || status !== 'ACTIVE';
 
   return (
     <div className={`${className} ${isDisabled ? 'line-through' : ''}`}>

--- a/apps/web/components/shared/Timer.tsx
+++ b/apps/web/components/shared/Timer.tsx
@@ -2,11 +2,14 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 
+import { PRODUCT_STATUS } from '@web/constants';
+import { ProductStatus } from '@web/types';
+
 interface TimerProps {
   startTime: string;
   currentPrice: number;
   minPrice: number;
-  status: 'ACTIVE' | 'SOLD' | 'CANCEL';
+  status: ProductStatus;
   className?: string;
 }
 
@@ -39,7 +42,7 @@ const Timer = ({ startTime, currentPrice, minPrice, status, className }: TimerPr
 
     const updateTimer = () => {
       // status가 ACTIVE가 아니거나 currentPrice와 minPrice가 같으면 타이머를 비활성화
-      if (status !== 'ACTIVE' || currentPrice === minPrice) {
+      if (status !== PRODUCT_STATUS.ACTIVE || currentPrice === minPrice) {
         setRemainingSeconds(0);
         if (animationFrameRef.current) {
           cancelAnimationFrame(animationFrameRef.current);
@@ -84,7 +87,7 @@ const Timer = ({ startTime, currentPrice, minPrice, status, className }: TimerPr
   const formattedMinutes = String(minutes).padStart(2, '0');
   const formattedSeconds = String(seconds).padStart(2, '0');
 
-  const isDisabled = currentPrice === minPrice || status !== 'ACTIVE';
+  const isDisabled = currentPrice === minPrice || status !== PRODUCT_STATUS.ACTIVE;
 
   return (
     <div className={`${className} ${isDisabled ? 'line-through' : ''}`}>

--- a/apps/web/hooks/products/useCurrentPrice.ts
+++ b/apps/web/hooks/products/useCurrentPrice.ts
@@ -2,10 +2,9 @@
 
 import { useState, useEffect } from 'react';
 
-import { PRODUCT_STATUS } from '@/constants';
-import type { ProductStatus } from '@/types';
-
 import { calculateCurrentPrice } from '@/utils/products';
+import { PRODUCT_STATUS } from '@web/constants';
+import type { ProductStatus } from '@web/types';
 
 interface AuctionPriceInfo {
   startPrice: number;

--- a/apps/web/hooks/products/useCurrentPrice.ts
+++ b/apps/web/hooks/products/useCurrentPrice.ts
@@ -2,6 +2,9 @@
 
 import { useState, useEffect } from 'react';
 
+import { PRODUCT_STATUS } from '@/constants';
+import type { ProductStatus } from '@/types';
+
 import { calculateCurrentPrice } from '@/utils/products';
 
 interface AuctionPriceInfo {
@@ -9,6 +12,7 @@ interface AuctionPriceInfo {
   minPrice: number;
   decreaseUnit: number;
   auctionStartedAt: string;
+  status: ProductStatus;
 }
 
 export const useCurrentPrice = ({
@@ -16,12 +20,21 @@ export const useCurrentPrice = ({
   minPrice,
   decreaseUnit,
   auctionStartedAt,
+  status,
 }: AuctionPriceInfo): number => {
-  const [currentPrice, setCurrentPrice] = useState<number>(() =>
-    calculateCurrentPrice(startPrice, minPrice, decreaseUnit, auctionStartedAt)
-  );
+  const [currentPrice, setCurrentPrice] = useState<number>(() => {
+    if (status !== PRODUCT_STATUS.ACTIVE) {
+      return startPrice;
+    }
+    return calculateCurrentPrice(startPrice, minPrice, decreaseUnit, auctionStartedAt);
+  });
 
   useEffect(() => {
+    if (status !== PRODUCT_STATUS.ACTIVE) {
+      setCurrentPrice(startPrice);
+      return;
+    }
+
     const timer = setInterval(() => {
       const newPrice = calculateCurrentPrice(startPrice, minPrice, decreaseUnit, auctionStartedAt);
 
@@ -30,7 +43,7 @@ export const useCurrentPrice = ({
     }, 1000); // 1초마다 가격 확인
 
     return () => clearInterval(timer);
-  }, [startPrice, minPrice, decreaseUnit, auctionStartedAt]);
+  }, [startPrice, minPrice, decreaseUnit, auctionStartedAt, status]);
 
   return currentPrice;
 };

--- a/apps/web/lib/prisma/schema.prisma
+++ b/apps/web/lib/prisma/schema.prisma
@@ -79,7 +79,7 @@ model products {
   created_at         DateTime         @default(now()) @db.Timestamptz(6)
   updated_at         DateTime?        @db.Timestamptz(6)
   seller_user_id     String           @db.Uuid
-  auction_started_at DateTime?        @db.Timestamptz(6)
+  auction_started_at DateTime         @db.Timestamptz(6)
   bids               bids?
   chat_rooms         chat_rooms[]
   favorites          favorites[]

--- a/apps/web/services/bids/client/index.ts
+++ b/apps/web/services/bids/client/index.ts
@@ -1,1 +1,2 @@
 export { fetchBidHistory } from './fetchBidHistory';
+export { fetchBidByProductId } from './fetchBidByProduct';

--- a/apps/web/services/bids/client/index.ts
+++ b/apps/web/services/bids/client/index.ts
@@ -1,2 +1,1 @@
 export { fetchBidHistory } from './fetchBidHistory';
-export { fetchBidByProductId } from './fetchBidByProduct';

--- a/apps/web/services/bids/server/getBidByProduct.ts
+++ b/apps/web/services/bids/server/getBidByProduct.ts
@@ -1,0 +1,16 @@
+import { prisma } from '@web/lib/prisma';
+
+export const getBidByProduct = async (productId: number) => {
+  try {
+    const bid = await prisma.bids.findUnique({
+      where: {
+        product_id: BigInt(productId),
+      },
+    });
+    return bid;
+  } catch (error) {
+    console.error('Error fetching bid by product ID:', error);
+    console.error('Detailed error:', error); // 상세 에러 객체 로깅
+    throw error;
+  }
+};

--- a/apps/web/services/bids/server/getBidByProduct.ts
+++ b/apps/web/services/bids/server/getBidByProduct.ts
@@ -9,8 +9,6 @@ export const getBidByProduct = async (productId: number) => {
     });
     return bid;
   } catch (error) {
-    console.error('Error fetching bid by product ID:', error);
-    console.error('Detailed error:', error); // 상세 에러 객체 로깅
     throw error;
   }
 };

--- a/apps/web/services/bids/server/index.ts
+++ b/apps/web/services/bids/server/index.ts
@@ -1,2 +1,3 @@
 export * from './createBid';
 export * from './getBidHistory';
+export * from './getBidByProduct';

--- a/apps/web/services/products/server/fetchProductDetail.ts
+++ b/apps/web/services/products/server/fetchProductDetail.ts
@@ -24,6 +24,7 @@ export const fetchProductDetailWithPrisma = async (
         view_count: true,
         created_at: true,
         updated_at: true,
+        auction_started_at: true,
         seller_user_id: true,
         product_images: {
           select: {

--- a/apps/web/types/product/domain.ts
+++ b/apps/web/types/product/domain.ts
@@ -25,6 +25,7 @@ export interface Product {
   view_count: number;
   created_at: string;
   updated_at: string | null;
+  auction_started_at: string;
   seller_user_id: string;
   product_images: ProductImage[];
 }

--- a/apps/web/utils/products/product-mappers.ts
+++ b/apps/web/utils/products/product-mappers.ts
@@ -40,6 +40,7 @@ interface PrismaProductDetail {
   view_count: number;
   created_at: Date;
   updated_at: Date | null;
+  auction_started_at: Date;
   seller_user_id: string;
   product_images: Array<{
     image_id: bigint;
@@ -91,6 +92,7 @@ export const convertToProductDetailResponse = (
     view_count: product.view_count,
     created_at: product.created_at.toISOString(),
     updated_at: product.updated_at?.toISOString() ?? product.created_at.toISOString(),
+    auction_started_at: product.auction_started_at.toISOString(),
     seller_user_id: product.seller_user_id,
     product_images: product.product_images.map(
       (img): ProductImage => ({


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

- 경매 상태에 따라 타이머 UI 변경
- 현재가 계산시 경매 상태에 따라 setTimeout 계산 하지 않도록 로직 변경
- 경매 상태에 따라 입찰 버튼 UI 변경
- 특정 입찰 내역 조회하는 서버용 서비스 함수 구현
- 경매 상세 페이지 경매 종료시 현재가격 대신 낙찰가 보여주도록 구현
- 경매 리스트 경매 종료시 UI 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

### [경매 종료시 상세 페이지 UI]

<img width="30%" alt="스크린샷 2025-08-05 오전 10 44 37" src="https://github.com/user-attachments/assets/df89f9a9-715d-49e5-a9bd-dfef7a04f320" />

### [경매 중지시 상세 페이지 UI]

<img width="30%" alt="스크린샷 2025-08-05 오전 10 44 56" src="https://github.com/user-attachments/assets/18f63b47-6305-4141-823b-0f9e4636bd7a" />

### [경매 종료시 경매 리스트 카드 UI]

<img width="50%" alt="스크린샷 2025-08-05 오전 10 45 09" src="https://github.com/user-attachments/assets/1594e6da-a921-4824-84f1-295d916a12d6" />



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
