### PR TITLE
fix: 릴리즈 노트 작성 자동화 오류 수정 (#267)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       !contains(github.event.head_commit.message, 'skip-release') &&
-      !contains(github.event.head_commit.message, 'chore: bump version')
+      !contains(github.event.head_commit.message, 'chore: bump version') &&
+      !contains(github.event.head_commit.message, 'chore: update CHANGELOG.md') &&
+      github.event.head_commit.author.email != 'action@github.com'
     
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,27 @@ jobs:
         if: steps.check-release.outputs.need_release == 'true'
         run: |
           VERSION_NUMBER=$(echo ${{ steps.release-notes.outputs.NEW_VERSION }} | sed 's/^v//')
-          pnpm version $VERSION_NUMBER --no-git-tag-version
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add package.json
-          git commit -m "chore: bump version to ${{ steps.release-notes.outputs.NEW_VERSION }}"
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          
+          if [ "$VERSION_NUMBER" != "$CURRENT_VERSION" ]; then
+            echo "Updating version from $CURRENT_VERSION to $VERSION_NUMBER"
+            pnpm version $VERSION_NUMBER --no-git-tag-version
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git add package.json CHANGELOG.md
+            git commit -m "chore: bump version to ${{ steps.release-notes.outputs.NEW_VERSION }}"
+          else
+            echo "Version $VERSION_NUMBER is already set in package.json, skipping version update"
+            # CHANGELOG.md만 업데이트된 경우를 위해 커밋
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            if git diff --quiet CHANGELOG.md; then
+              echo "No changes to commit"
+            else
+              git add CHANGELOG.md
+              git commit -m "chore: update CHANGELOG.md for ${{ steps.release-notes.outputs.NEW_VERSION }}"
+            fi
+          fi
 
       - name: Create and push tag
         if: steps.check-release.outputs.need_release == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
 ## [1.1.0] - 2025-07-13
 
 ### Added


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안


## 📋 작업 내용

changelog.md를 업데이트 하는 깃허브 액션이 실행되서 changelog.md 파일이 업데이트 될 때마다
계속해서 깃허브 액션이 새로 실행되는 무한루프를 수정했습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
