### PR TITLE
[fix] PWA Manager UI 가독성 개선 (#277)

### DIFF
--- a/apps/web/components/shared/PWAManager.tsx
+++ b/apps/web/components/shared/PWAManager.tsx
@@ -50,7 +50,9 @@ export const PWAManager = () => {
           });
         }
       });
-    } catch {}
+    } catch (error) {
+      console.warn('[PWA] Service Worker registration failed:', error);
+    }
   }
 
   if (!isSupported) {
@@ -61,15 +63,18 @@ export const PWAManager = () => {
     <>
       {/* Install prompt for iOS users */}
       {isIOS && !isStandalone && (
-        <div className="fixed bottom-4 left-4 right-4 bg-bg-primary border border-border-primary rounded-lg p-4 shadow-lg z-50">
-          <div className="flex items-start space-x-3">
-            <div className="flex-1">
-              <h3 className="text-sm font-medium text-text-primary">앱을 홈 화면에 추가하세요</h3>
-              <p className="text-xs text-text-secondary mt-1">
-                공유 버튼 <span className="inline-block">⎋</span>을 누른 후 &quot;홈 화면에
-                추가&quot; <span className="inline-block">➕</span>를 선택하세요.
+        <aside
+          data-install-banner
+          className="fixed bottom-[var(--space-container)] left-[var(--space-container)] right-[var(--space-container)] bg-bg-primary p-container rounded-lg shadow-lg z-50"
+        >
+          <div className="flex items-start gap-md">
+            <div className="flex-1 text-text-inverse">
+              <h3 className="font-style-large">앱을 홈 화면에 추가해 보세요!</h3>
+              <p className="font-style-small mt-1">
+                공유 버튼을 누른 후 &quot;홈 화면에 추가&quot; 를 선택하세요.
               </p>
             </div>
+
             <button
               onClick={() => {
                 // Hide the banner (this would be stored in localStorage in a real app)
@@ -78,13 +83,13 @@ export const PWAManager = () => {
                   (banner as HTMLElement).style.display = 'none';
                 }
               }}
-              className="text-text-secondary hover:text-text-primary"
-              data-install-banner
+              aria-label="닫기"
+              className="font-style-large text-text-inverse inline-flex w-[16px] h-[16px]"
             >
               ✕
             </button>
           </div>
-        </div>
+        </aside>
       )}
     </>
   );


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안


## 📋 작업 내용

PWA 앱 설치 안내를 하는 UI 의 텍스트 문구가 잘 보이지 않고 버튼이 제대로 동작하지 않는 이슈 해결

<img width="324" height="137" alt="image" src="https://github.com/user-attachments/assets/e9028696-1c00-4311-8b92-3c842f1542ed" />


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="392" height="682" alt="image" src="https://github.com/user-attachments/assets/5dd0f679-1600-4552-a51e-79d112f0b097" />

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
