### PR TITLE
[perf] middleware에서 auth 로직이 엄격하지 않은 네트워크 요청 matcher에서 제거 (#280)

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -11,24 +11,16 @@ export const config = {
     /*
      * 인증이 필요한 모든 페이지들
      */
-    '/',
-    '/login',
-    '/signup',
-    '/location',
     '/chat/:path*',
-    '/mypage',
     '/mypage/:path*',
     '/products/:path*',
-    '/search',
 
     /*
      * 인증이 필요한 모든 API들
      */
-    '/api/products',
     '/api/products/:path*',
     '/api/my-info',
     '/api/bids/:path*',
-    '/api/favorites/:path*',
     '/api/images/:path*',
     '/api/chat/:path*',
     '/api/user/:path*',


### PR DESCRIPTION
…에서 제거 (#280)

# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- middleware가 실행하는 updateSession의 로직이 거의 0.8~1초에 가까운 속도를 확인하여 엄격한 인증로직이 필요하지 않을 경우는 matcher에서 제거하여 cookie의 userd 여부로 라우팅 판단히도록 하기 위함

## 🔧 변경 사항

- 📃 middleware.ts

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="357" height="667" alt="image" src="https://github.com/user-attachments/assets/aa1c8caf-b855-4b4f-b960-12f15ccf5a7b" />

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
