### PR TITLE
[hotfix] 로그인 후 인증 로직 누락되어 다시 middleware의 matcher 복구 (#282)

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -11,16 +11,24 @@ export const config = {
     /*
      * 인증이 필요한 모든 페이지들
      */
+    '/',
+    '/login',
+    '/signup',
+    '/location',
     '/chat/:path*',
+    '/mypage',
     '/mypage/:path*',
     '/products/:path*',
+    '/search',
 
     /*
      * 인증이 필요한 모든 API들
      */
+    '/api/products',
     '/api/products/:path*',
     '/api/my-info',
     '/api/bids/:path*',
+    '/api/favorites/:path*',
     '/api/images/:path*',
     '/api/chat/:path*',
     '/api/user/:path*',


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

- 로그인 직후 배포 환경 에러 비상사태

## 📋 작업 내용

- middleware matcher list 정리 후 로그인 후 쿠키 셋팅하지 않아서 생긴 이슈이므로 일단 기존대로 복구

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
